### PR TITLE
simplify map; remove needless dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,8 +16,6 @@ Imports:
     incidence,
     ISOweek,
     knitr,
-    lwgeom,
-    OpenStreetMap,
     outbreaks,
     raster,
     rio,
@@ -28,9 +26,7 @@ Imports:
     sf,
     survey,
     tibble,
-    tidyr,
-    tmap,
-    tmaptools
+    tidyr
 Suggests:
     testthat
 Encoding: UTF-8

--- a/inst/rmarkdown/templates/outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/outbreak/skeleton/skeleton.Rmd
@@ -666,7 +666,9 @@ map <- st_as_sf(map)
 # subsetting shapefiles 
 
 # Subset map to provinces of interest
-mapsub <- map %>% filter(NAME_1 %in% unique(linelist_cleaned$province))
+mapsub <- map %>% 
+  filter(NAME_1 %in% unique(linelist_cleaned$province)) %>%
+  rmapshaper::ms_simplify(keep = 0.1)
 
 ```
 
@@ -724,8 +726,8 @@ ggplot() +
 ## unsure how other functions would react to an sf + dataframe obj though
 ## It doesn't allow for missing values in the coordinates.
 cases <- linelist_cleaned %>% 
-          filter(!is.na(lat) | !is.na(lon)) %>% # Remove missing coordinates
-          st_as_sf(coords = c("lon", "lat"), crs = 4326)
+  filter(!is.na(lat) | !is.na(lon)) %>% # Remove missing coordinates
+  st_as_sf(coords = c("lon", "lat"), crs = 4326)
 ```
 
 ##### Dot maps


### PR DESCRIPTION
This addresses some hanging chads from #56. When I attempted to run the new vignette on my machine, it was taking over 20 minutes to render the shapefile because the simplification step was removed. Moreover, I still couldn't install the package because the Java dependencies were still there.

This PR

1. adds `rmapshaper::ms_simplify()` to the script
2. removes unneeded dependencies
3. brings the indentation of a couple of lines down