### PR TITLE
use sf instead of rmapshaper for simplification

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,6 @@ Imports:
     raster,
     rio,
     rlang,
-    rmapshaper,
     rmarkdown,
     scales,
     sf,

--- a/inst/rmarkdown/templates/outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/outbreak/skeleton/skeleton.Rmd
@@ -666,9 +666,10 @@ map <- st_as_sf(map)
 # subsetting shapefiles 
 
 # Subset map to provinces of interest
+suppressWarnings({
 mapsub <- map %>% 
   filter(NAME_1 %in% unique(linelist_cleaned$province)) %>%
-  rmapshaper::ms_simplify(keep = 0.1)
+  sf::st_simplify(preserveTopology = TRUE, dTolerance = 0.05)
 
 ```
 
@@ -762,7 +763,8 @@ mapsub <- left_join(mapsub, counts, by = c("NAME_1" = "province"))
 ggplot() +
   annotation_map_tile(zoom = NULL, cachedir = "maps/tiles") + # osm tiles
   geom_sf(data = mapsub, aes(fill = AR), col = "grey50") + # shapefile as polygon
-  annotation_scale() # add a scalebar
+  annotation_scale() + # add a scalebar
+  scale_fill_viridis_c(option = "C") # color the scale to be perceptually uniform
 
 
 ```


### PR DESCRIPTION
This will address https://github.com/R4EPI/sitrep/pull/60#issuecomment-458883759 by removing `rmapshaper::ms_simplify()` in favor of `sf::st_simplify()`

I've also put viridis in the chorleuapoelth map