### PR TITLE
fix potential error that would occur with NSE

### DIFF
--- a/inst/rmarkdown/templates/cholera_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/cholera_outbreak/skeleton/skeleton.Rmd
@@ -667,7 +667,7 @@ were dead on arrival.
 Among those who died, the time to death is shown below. 
 
 ```{r describe_time_to_death}
-DIED <- grepl("Dead", linelist_cleaned$exit_status)
+linelist_cleaned$DIED <- grepl("Dead", linelist_cleaned$exit_status)
 
 filter(linelist_cleaned, DIED) %>% 
   descriptive(counter = "time_to_death", coltotals = TRUE) %>% 


### PR DESCRIPTION
DIED was a variable defined outside of the data frame, but used
inside several tidyverse functions which expect column names as
inputs first and foremost. By adding this variable to the data,
we can avoid confusion.