### PR TITLE
add percent option to fmt_* functions

### DIFF
--- a/R/inline_fun.R
+++ b/R/inline_fun.R
@@ -10,6 +10,8 @@
 #' @param l the column of the lower bound (defaults to the fourth column). Otherwise, a number
 #' @param u the column of the upper bound (defaults to the fifth column), otherwise, a number
 #' @param digits the number of digits to show
+#' @param percent if `TRUE` (default), converts the number to percent, otherwise
+#'   it's treated as a raw value
 #' @return a text string in the format of "e\% (CI l--u)"
 #' @rdname fmt_ci
 #' @export
@@ -17,35 +19,37 @@
 #'
 #' cfr <- case_fatality_rate(10, 50)
 #' fmt_ci_df(cfr)
-#' fmt_ci_df(cfr, d = 1)
+#' fmt_ci_df(cfr)
+#'
 #' # If the data starts at a different column, specify a different number
 #' fmt_ci_df(cfr[-1], 2, d = 1)
 #'
-#' # It's also possible to provide numbers directly
-#' fmt_ci(pi, pi - runif(1), pi + runif(1))
-fmt_ci <- function(e = numeric(), l = numeric(), u = numeric(), digits = 2) {
+#' # It's also possible to provide numbers directly and remove the percent sign.
+#' fmt_ci(pi, pi - runif(1), pi + runif(1), percent = FALSE)
+fmt_ci <- function(e = numeric(), l = numeric(), u = numeric(), digits = 2, percent = TRUE) {
   stopifnot(is.numeric(e), is.numeric(l), is.numeric(u), is.numeric(digits))
-  msg <- "%.2f%% (CI %.2f--%.2f)"
+  msg <- "%s (CI %.2f--%.2f)"
   msg <- gsub("2", digits, msg)
+  e <- if (percent) scales::percent(e, scale = 1, accuracy = 1/(10^digits)) else scales::number(e, accuracy = 1/(10^digits)) 
   sprintf(msg, e, l, u)
 } 
 
 #' @export
 #' @rdname fmt_ci
-fmt_pci <- function(e = numeric(), l = numeric(), u = numeric(), digits = 2) {
-  fmt_ci(e = e * 100, l = l * 100, u = u * 100, digits = digits)
+fmt_pci <- function(e = numeric(), l = numeric(), u = numeric(), digits = 2, percent = TRUE) {
+  fmt_ci(e = e * 100, l = l * 100, u = u * 100, digits = digits, percent = percent)
 }
 
 #' @export
 #' @rdname fmt_ci
-fmt_pci_df <- function(x, e = 3, l = e + 1, u = e + 2, digits = 2) {
-  fmt_pci(x[[e]], x[[l]], x[[u]], digits = digits)
+fmt_pci_df <- function(x, e = 3, l = e + 1, u = e + 2, digits = 2, percent = TRUE) {
+  fmt_pci(x[[e]], x[[l]], x[[u]], digits = digits, percent = percent)
 }
 
 #' @export
 #' @rdname fmt_ci
-fmt_ci_df <- function(x, e = 3, l = e + 1, u = e + 2, digits = 2) {
-  fmt_ci(x[[e]], x[[l]], x[[u]], digits = digits)
+fmt_ci_df <- function(x, e = 3, l = e + 1, u = e + 2, digits = 2, percent = TRUE) {
+  fmt_ci(x[[e]], x[[l]], x[[u]], digits = digits, percent = percent)
 }
 
 #' @export

--- a/R/inline_fun.R
+++ b/R/inline_fun.R
@@ -30,7 +30,8 @@ fmt_ci <- function(e = numeric(), l = numeric(), u = numeric(), digits = 2, perc
   stopifnot(is.numeric(e), is.numeric(l), is.numeric(u), is.numeric(digits))
   msg <- "%s (CI %.2f--%.2f)"
   msg <- gsub("2", digits, msg)
-  e <- if (percent) scales::percent(e, scale = 1, accuracy = 1/(10^digits)) else scales::number(e, accuracy = 1/(10^digits)) 
+  fun <- if (percent) match.fun(scales::percent) else match.fun(scales::number)
+  e   <- fun(e, scale = 1, accuracy = 1/(10^digits), big.mark = ",") 
   sprintf(msg, e, l, u)
 } 
 

--- a/man/fmt_ci.Rd
+++ b/man/fmt_ci.Rd
@@ -8,13 +8,17 @@
 \alias{merge_ci_df}
 \title{Helper to format confidence interval for text}
 \usage{
-fmt_ci(e = numeric(), l = numeric(), u = numeric(), digits = 2)
+fmt_ci(e = numeric(), l = numeric(), u = numeric(), digits = 2,
+  percent = TRUE)
 
-fmt_pci(e = numeric(), l = numeric(), u = numeric(), digits = 2)
+fmt_pci(e = numeric(), l = numeric(), u = numeric(), digits = 2,
+  percent = TRUE)
 
-fmt_pci_df(x, e = 3, l = e + 1, u = e + 2, digits = 2)
+fmt_pci_df(x, e = 3, l = e + 1, u = e + 2, digits = 2,
+  percent = TRUE)
 
-fmt_ci_df(x, e = 3, l = e + 1, u = e + 2, digits = 2)
+fmt_ci_df(x, e = 3, l = e + 1, u = e + 2, digits = 2,
+  percent = TRUE)
 
 merge_ci_df(x, e = 3, l = e + 1, u = e + 2, digits = 2)
 }
@@ -26,6 +30,9 @@ merge_ci_df(x, e = 3, l = e + 1, u = e + 2, digits = 2)
 \item{u}{the column of the upper bound (defaults to the fifth column), otherwise, a number}
 
 \item{digits}{the number of digits to show}
+
+\item{percent}{if \code{TRUE} (default), converts the number to percent, otherwise
+it's treated as a raw value}
 
 \item{x}{a data frame}
 }
@@ -42,10 +49,11 @@ which will render like this: "The CFR for Bamako is 20.00\% (CI 11.24--33.04)"
 
 cfr <- case_fatality_rate(10, 50)
 fmt_ci_df(cfr)
-fmt_ci_df(cfr, d = 1)
+fmt_ci_df(cfr)
+
 # If the data starts at a different column, specify a different number
 fmt_ci_df(cfr[-1], 2, d = 1)
 
-# It's also possible to provide numbers directly
-fmt_ci(pi, pi - runif(1), pi + runif(1))
+# It's also possible to provide numbers directly and remove the percent sign.
+fmt_ci(pi, pi - runif(1), pi + runif(1), percent = FALSE)
 }


### PR DESCRIPTION
Now for things like attack rate, you can place `percent = FALSE` in the function call to remove that percent symbol.