### PR TITLE
Add rowtotals and coltotals to tabulate_survey

### DIFF
--- a/R/relabel_proportions.R
+++ b/R/relabel_proportions.R
@@ -7,7 +7,7 @@
 #' - augment_redundant will take a regular expression and rename columns 
 #'     via [gsub()]. 
 #' @param x a data frame
-#' @param a series of keys and values to replace columns that match specific
+#' @param ... a series of keys and values to replace columns that match specific
 #'   patterns.
 #' @export
 #' @author Zhian N. Kamvar

--- a/man/rename_redundant.Rd
+++ b/man/rename_redundant.Rd
@@ -12,7 +12,7 @@ augment_redundant(x, ...)
 \arguments{
 \item{x}{a data frame}
 
-\item{a}{series of keys and values to replace columns that match specific
+\item{...}{a series of keys and values to replace columns that match specific
 patterns.}
 }
 \description{

--- a/man/tabulate_survey.Rd
+++ b/man/tabulate_survey.Rd
@@ -6,11 +6,12 @@
 \title{Tabulate survey design objects by a categorical and another stratifying variable}
 \usage{
 tabulate_survey(x, var, strata = NULL, pretty = TRUE, wide = TRUE,
-  digits = 1, method = "logit", deff = TRUE)
+  digits = 1, method = "logit", deff = FALSE, rowtotals = FALSE,
+  coltotals = FALSE)
 
 tabulate_binary_survey(x, ..., strata = NULL, keep = NULL,
   invert = FALSE, pretty = TRUE, wide = TRUE, digits = 1,
-  method = "logit")
+  method = "logit", deff = FALSE)
 }
 \arguments{
 \item{x}{a survey design object}
@@ -36,6 +37,12 @@ interval. Defaults to "logit"}
 \item{deff}{a logical indicating if the design effect should be reported.
 Defaults to "TRUE"}
 
+\item{rowtotals}{if \code{TRUE} and \code{strata} is defined, then an extra "Total"
+column will be added tabulating all of the rows across strata.}
+
+\item{coltotals}{if \code{TRUE} a new row with totals for each "n" column is
+created.}
+
 \item{...}{binary variables for tabulation}
 
 \item{keep}{a vector of binary values to keep}
@@ -48,6 +55,10 @@ a long or wide tibble with tabulations n, ci, and deff
 \description{
 Tabulate survey design objects by a categorical and another stratifying variable
 }
+\note{
+The proportions presented here represent the proportions of the total
+population, not for the stratified samples
+}
 \examples{
 library(srvyr)
 library(survey)
@@ -56,16 +67,16 @@ data(api)
 # stratified sample
 s <- apistrat \%>\%
   as_survey_design(strata = stype, weights = pw) \%>\%
-  tabulate_survey(stype, awards)
+  tabulate_survey(stype, awards, coltotals = TRUE, rowtotals = TRUE, deff = TRUE)
 s
 
 # making things pretty
 s \%>\%
   # wrap all "n" variables in braces (note space before n).
-  augment_redundant(" n" = " (n)") \%>\% 
+  augment_redundant(" n" = " (n)") \%>\%
   # relabel all columns containing "prop" to "\% (95\% CI)"
   rename_redundant("ci"   = "\% (95\% CI)",
-                   "deff" = "Design Effect") 
+                   "deff" = "Design Effect")
 
 # long data
 apistrat \%>\%


### PR DESCRIPTION
This is related to one of the tick boxes in #70:

> tabulate_survey when stratified - possible to give option for row or col props, as well as of total?? (same as we do for the descriptive functin)

Currently we have the totals for N, but not the props... This part would be a bit tricky because I think we would basically need to re-run the data without the stratification to get the accurate proportions and it seems like it will get messy :grimacing: 