### PR TITLE
add explicit_missing argument to descriptive table

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ Imports:
     huxtable,
     tidyr
 Suggests:
-    testthat,
+    testthat (>= 2.1.0),
     sessioninfo
 Remotes:
   reconhub/linelist,

--- a/R/check_templates.R
+++ b/R/check_templates.R
@@ -20,7 +20,8 @@ check_sitrep_templates <- function(templates = available_sitrep_templates(),
                                    path = tempdir(), 
                                    quiet = FALSE, 
                                    progress = FALSE, 
-                                   mustwork = FALSE) {
+                                   mustwork = FALSE,
+                                   output_format = NULL) {
 
   stopifnot(is.character(templates), length(templates) > 0)
 
@@ -28,7 +29,7 @@ check_sitrep_templates <- function(templates = available_sitrep_templates(),
   names(res) <- templates
   for (i in templates) {
     if (!quiet) message(sprintf("Building %s", i))
-    res[[i]] <- build_sitrep_template(i, path, progress)
+    res[[i]] <- build_sitrep_template(i, path, progress, output_format)
   }
   if (mustwork && any(errs <- vapply(res, inherits, logical(1), "error"))) {
     errs <- paste(names(res)[errs], collapse = ", ")
@@ -72,7 +73,7 @@ available_sitrep_templates <- function(categorise = FALSE, ...) {
 }
 
 # Draft and build a sitrep template (internal)
-build_sitrep_template <- function(template, path, progress = FALSE) {
+build_sitrep_template <- function(template, path, progress = FALSE, output_format = NULL) {
 
   path_to_template <- file.path(path, sprintf("%s.Rmd", basename(template)))
   res <- tryCatch({
@@ -82,6 +83,7 @@ build_sitrep_template <- function(template, path, progress = FALSE) {
                      edit = FALSE
                      )
     rmarkdown::render(path_to_template,
+                      output_format = output_format,
                       output_dir = path,
                       encoding = "UTF-8",
                       quiet = !progress

--- a/R/check_templates.R
+++ b/R/check_templates.R
@@ -9,6 +9,10 @@
 #'   Defaults to `FALSE`
 #' @param mustwork if `TRUE`, then the templates must work for the function to
 #'   succeed. Defaults to `FALSE`, which will simply print the errors. 
+#' @param output_format a character defining the output formats to use for the
+#'   template files. Defaults to the output_format defined in the templates
+#'   (which is `word_document`), but can be modified to `html_document` for
+#'   cross-platform cromulence checking.
 #' 
 #' @return the path where the templates were built.
 #' @export

--- a/R/descriptive-table.R
+++ b/R/descriptive-table.R
@@ -61,10 +61,10 @@
 #'
 #' # Cleaning linelist data
 #' linelist_clean <- clean_variable_spelling(
-#'   x = linelist,
-#'   wordlists = filter(measles_dict, !is.na(option_code)),
+#'   x             = linelist,
+#'   wordlists     = filter(measles_dict, !is.na(option_code)),
 #'   spelling_vars = "data_element_shortname",
-#'   sort_by = "option_order_in_set"
+#'   sort_by       = "option_order_in_set"
 #' )
 #' 
 #' # get a descriptive table by sex
@@ -132,6 +132,11 @@ descriptive <- function(df, counter, grouper = NULL, multiplier = 100, digits = 
     # change to wide format, to have "grouper" var levels as columns
     count_data <- tidyr::gather(count_data, key = "variable", value = "value", c(.data$n, .data$prop))
     count_data <- tidyr::unite(count_data, "temp", !!sym_group, .data$variable, sep = "_")
+    if (is.factor(df[[grouper]])) {
+      lvls <- rep(levels(df[[grouper]]), each = 2)
+      lvls <- paste0(lvls, c("_n", "_prop"))
+      count_data$temp <- factor(count_data$temp, levels = lvls)
+    }
     count_data <- tidyr::spread(count_data, .data$temp, .data$value)
 
   } else {

--- a/R/descriptive-table.R
+++ b/R/descriptive-table.R
@@ -79,15 +79,13 @@
 #'
 #' }) }
 #' 
-descriptive <- function(df, counter, grouper = NA, multiplier = 100, digits = 1,
+descriptive <- function(df, counter, grouper = NULL, multiplier = 100, digits = 1,
                         proptotal = FALSE, coltotals = FALSE, rowtotals = FALSE,
                         single_row = FALSE, explicit_missing = TRUE) {
 
 
-  # sym_count <- rlang::sym(counter)
   counter <- tidyselect::vars_select(colnames(df), !!enquo(counter))
   grouper <- tidyselect::vars_select(colnames(df), !!enquo(grouper))
-  # grouper <- tidyselect::vars_select(colnames(df), grouper)
   sym_count <- rlang::sym(counter)
 
   

--- a/R/descriptive-table.R
+++ b/R/descriptive-table.R
@@ -49,13 +49,46 @@
 #' @importFrom rlang sym "!!" ".data" ":="
 #' @importFrom stats setNames
 #' @export
+#' @examples 
+#' have_packages <- require("dplyr") && require("linelist")
+#' if (have_packages) { withAutoprint({
+#' 
+#' # Simulating linelist data
+#'
+#' linelist     <- gen_data("Measles")
+#' measles_dict <- msf_dict("Measles", compact = FALSE) %>%
+#'   select(option_code, option_name, everything())
+#'
+#' # Cleaning linelist data
+#' linelist_clean <- clean_variable_spelling(
+#'   x = linelist,
+#'   wordlists = filter(measles_dict, !is.na(option_code)),
+#'   spelling_vars = "data_element_shortname",
+#'   sort_by = "option_order_in_set"
+#' )
+#' 
+#' # get a descriptive table by sex
+#' descriptive(linelist_clean, "sex")
+#' 
+#' # describe prenancy statistics, but remove missing data from the tally
+#' descriptive(linelist_clean, "trimester", explicit_missing = FALSE)
+#' 
+#' # describe prenancy statistics, stratifying by vitamin A perscription
+#' descriptive(linelist_clean, "trimester", "prescribed_vitamin_a", explicit_missing = FALSE)
+#' 
+#'
+#' }) }
+#' 
 descriptive <- function(df, counter, grouper = NA, multiplier = 100, digits = 1,
                         proptotal = FALSE, coltotals = FALSE, rowtotals = FALSE,
                         single_row = FALSE, explicit_missing = TRUE) {
 
-  # Using rlang::sym() allows us to use quoted arguments
-  # If we wanted to go full NSE, we would use rlang::enquo() instead
+
+  # sym_count <- rlang::sym(counter)
+  counter <- tidyselect::vars_select(colnames(df), counter)
+  # grouper <- tidyselect::vars_select(colnames(df), grouper)
   sym_count <- rlang::sym(counter)
+
   
   if (explicit_missing) {
     df[[counter]] <- forcats::fct_explicit_na(df[[counter]], "Missing")

--- a/R/population_weights.R
+++ b/R/population_weights.R
@@ -11,7 +11,6 @@
 #'   "weight_ID"
 #' @author Zhian N. Kamvar Alex Spina
 #' @export
-#' @examples
 add_weights <- function(x, p, ..., population = population, weight = weight, weight_ID = weight_ID) {
 
   .dots      <- rlang::enquos(...)

--- a/R/template_data_frame.R
+++ b/R/template_data_frame.R
@@ -35,6 +35,19 @@ template_data_frame_categories <- function(dat_dict, numcases, varnames, survey 
 }
 
 
+# Enforces timing between two columns in a data frame.
+#
+# The data in the first column must come before the second column. If the timing
+# isn't correct, then force the timing to be correct by making the second column
+# bigger than the first by `add`.
+enforce_timing <- function(x, first, second, add = 2) {
+
+  mistakes              <- x[[second]] <= x[[first]]
+  x[[second]][mistakes] <- x[[first]][mistakes] + add
+  x 
+
+}
+
 # sample of a single value and NA
 sample_single <- function(x, size, prob = 0.1) {
   sample(c(x, NA), size = size, prob = c(prob, 1 - prob), replace = TRUE)

--- a/inst/rmarkdown/templates/ajs_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/ajs_outbreak/skeleton/skeleton.Rmd
@@ -796,8 +796,7 @@ Cases by age group and sex
 
 ```{r describe_by_age_group_and_sex}
 descriptive(linelist_cleaned, "age_group", "sex", coltotals = TRUE, rowtotals = TRUE) %>% 
-  rename("Age group" = age_group,
-         "Missing (n)" = NA_n) %>%
+  rename("Age group" = age_group) %>%
   rename_redundant(prop = "%") %>%
   augment_redundant("_n$" = " cases (n)") %>%
   kable(digits = 2)
@@ -808,8 +807,7 @@ Alternatively if you would like proportions to be of the total population, use t
 ```{r total_props_agegroup_sex}
 descriptive(linelist_cleaned, "age_group", "sex", 
             coltotals = TRUE, rowtotals = TRUE, proptotal = TRUE) %>% 
-  rename("Age group" = age_group,
-         "Missing (n)" = NA_n) %>%
+  rename("Age group" = age_group) %>%
   rename_redundant(prop = "%") %>%
   augment_redundant("_n$" = " cases (n)") %>%
   kable(digits = 2)

--- a/inst/rmarkdown/templates/cholera_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/cholera_outbreak/skeleton/skeleton.Rmd
@@ -716,8 +716,7 @@ Cases by age group and sex
 
 ```{r describe_by_age_group_and_sex}
 descriptive(linelist_cleaned, "age_group", "sex", coltotals = TRUE, rowtotals = TRUE) %>% 
-  rename("Age group (years)" = age_group,
-         "Missing (n)" = NA_n) %>%
+  rename("Age group" = age_group) %>%
   rename_redundant(prop = "%") %>%
   augment_redundant("_n$" = " cases (n)") %>%
   kable(digits = 2)
@@ -728,8 +727,7 @@ Alternatively if you would like proportions to be of the total population, use t
 ```{r total_props_agegroup_sex}
 descriptive(linelist_cleaned, "age_group", "sex", 
             coltotals = TRUE, rowtotals = TRUE, proptotal = TRUE) %>% 
-  rename("Age group (years)" = age_group,
-         "Missing (n)" = NA_n) %>%
+  rename("Age group" = age_group) %>%
   rename_redundant(prop = "%") %>%
   augment_redundant("_n$" = " cases (n)") %>%
   kable(digits = 2)

--- a/inst/rmarkdown/templates/measles_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/measles_outbreak/skeleton/skeleton.Rmd
@@ -1187,7 +1187,7 @@ Alternatively, you could stratify by sex among a subset of only inpatients.
 
 ```{r incidence_by_sex_facility, message = FALSE}
 
-inc_week_7_sex_fac <- inelist_cleaned %>%
+inc_week_7_sex_fac <- linelist_cleaned %>%
   filter(patient_facility_type == "Inpatient") %>%
   with(incidence(date_of_onset, interval = "Monday week", groups = sex))
 

--- a/inst/rmarkdown/templates/measles_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/measles_outbreak/skeleton/skeleton.Rmd
@@ -776,8 +776,7 @@ Cases by age group and sex
 
 ```{r describe_by_age_group_and_sex}
 descriptive(linelist_cleaned, "age_category", "sex", coltotals = TRUE, rowtotals = TRUE) %>% 
-  rename("Age group" = age_category,
-         "Missing (n)" = NA_n) %>%
+  rename("Age group" = age_category) %>%
   rename_redundant(prop = "%") %>%
   augment_redundant("_n$" = " cases (n)") %>%
   kable(digits = 2)
@@ -788,8 +787,7 @@ Alternatively if you would like proportions to be of the total population, use t
 ```{r total_props_agegroup_sex}
 descriptive(linelist_cleaned, "age_category", "sex", 
             coltotals = TRUE, rowtotals = TRUE, proptotal = TRUE) %>% 
-  rename("Age group" = age_category,
-         "Missing (n)" = NA_n) %>%
+  rename("Age group" = age_category) %>%
   rename_redundant(prop = "%") %>%
   augment_redundant("_n$" = " cases (n)") %>%
   kable(digits = 2)

--- a/inst/rmarkdown/templates/meningitis_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/meningitis_outbreak/skeleton/skeleton.Rmd
@@ -790,8 +790,7 @@ Cases by age group and sex
 
 ```{r describe_by_age_group_and_sex}
 descriptive(linelist_cleaned, "age_category", "sex", coltotals = TRUE, rowtotals = TRUE) %>% 
-  rename("Age group" = age_category,
-         "Missing (n)" = NA_n) %>%
+  rename("Age group" = age_category) %>%
   rename_redundant(prop = "%") %>%
   augment_redundant("_n$" = " cases (n)") %>%
   kable(digits = 2)
@@ -802,8 +801,7 @@ Alternatively if you would like proportions to be of the total population, use t
 ```{r total_props_agegroup_sex}
 descriptive(linelist_cleaned, "age_category", "sex", 
             coltotals = TRUE, rowtotals = TRUE, proptotal = TRUE) %>% 
-  rename("Age group" = age_category,
-         "Missing (n)" = NA_n) %>%
+  rename("Age group" = age_category) %>%
   rename_redundant(prop = "%") %>%
   augment_redundant("_n$" = " cases (n)") %>%
   kable(digits = 2)

--- a/inst/rmarkdown/templates/meningitis_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/meningitis_outbreak/skeleton/skeleton.Rmd
@@ -1218,7 +1218,7 @@ Alternatively, you could stratify by sex among a subset of only inpatients.
 
 ```{r incidence_by_sex_facility, message = FALSE}
 
-inc_week_7_sex_fac <- inelist_cleaned %>%
+inc_week_7_sex_fac <- linelist_cleaned %>%
   filter(patient_facility_type == "Inpatient") %>%
   with(incidence(date_of_onset, interval = "Monday week", groups = sex))
 

--- a/inst/rmarkdown/templates/outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/outbreak/skeleton/skeleton.Rmd
@@ -297,13 +297,9 @@ Cases by age group and definition
 # get counts and props of age groups by case definition 
 # include column and row totals 
 descriptive(linelist_cleaned, "age_group", "case_def", coltotals = TRUE, rowtotals = TRUE) %>% 
-  rename("Age group (years)" = age_group, 
-         "Confirmed cases (n)" = Confirmed_n, 
-         "%" = Confirmed_prop, 
-         "Probable cases (n)" = Probable_n, 
-         "%" = Probable_prop,
-         "Suspected cases (n)" = Suspected_n, 
-         "%" = Suspected_prop) %>% 
+  rename("Age group (years)" = age_group) %>%
+  rename_redundant(prop = "%") %>%
+  augment_redundant("_n$" = " cases (n)") %>%
   kable(digits = 2)
 ```
 
@@ -314,13 +310,9 @@ Cases by age group and sex
 
 ```{r describe_by_age_group_and_sex}
 descriptive(linelist_cleaned, "age_group", "sex") %>% 
-  rename("Age group (years)" = age_group, 
-         "Female cases (n)" = Female_n, 
-         "%" = Female_prop, 
-         "Male cases (n)" = Male_n, 
-         "%" = Male_prop,
-         "Missing (n)" = NA_n, 
-         "%" = NA_prop) %>% 
+  rename("Age group (years)" = age_group) %>%
+  rename_redundant(prop = "%") %>%
+  augment_redundant("_n$" = " cases (n)") %>%
   kable(digits = 2)
 ```
 
@@ -332,12 +324,18 @@ descriptive(linelist_cleaned, "age_group", "sex") %>%
 # for example to only have confirmed cases 
 filter(linelist_cleaned, case_def == "Confirmed") %>%
   descriptive("age_group", "sex") %>% 
+  rename("Age group (years)" = age_group) %>%
+  rename_redundant(prop = "%") %>%
+  augment_redundant("_n$" = " cases (n)") %>%
   kable(digits = 2)
 
 
 # alternatively you could show a single age group 
 filter(linelist_cleaned, age_group == "10-29") %>%
   descriptive("age_group", "sex") %>% 
+  rename("Age group (years)" = age_group) %>%
+  rename_redundant(prop = "%") %>%
+  augment_redundant("_n$" = " cases (n)") %>%
   kable(digits = 2)
 ```
 

--- a/man/check_sitrep_templates.Rd
+++ b/man/check_sitrep_templates.Rd
@@ -6,7 +6,7 @@
 \usage{
 check_sitrep_templates(templates = available_sitrep_templates(),
   path = tempdir(), quiet = FALSE, progress = FALSE,
-  mustwork = FALSE)
+  mustwork = FALSE, output_format = NULL)
 }
 \arguments{
 \item{templates}{a vector of templates to create and render}
@@ -22,6 +22,11 @@ Defaults to \code{FALSE}}
 
 \item{mustwork}{if \code{TRUE}, then the templates must work for the function to
 succeed. Defaults to \code{FALSE}, which will simply print the errors.}
+
+\item{output_format}{a character defining the output formats to use for the
+template files. Defaults to the output_format defined in the templates
+(which is \code{word_document}), but can be modified to \code{html_document} for
+cross-platform cromulence checking.}
 }
 \value{
 the path where the templates were built.

--- a/man/descriptive.Rd
+++ b/man/descriptive.Rd
@@ -64,3 +64,34 @@ columns represent counts and proportions of the values within those
 variables. This function assumes that all of the variables have the same
 values (e.g. Yes/No values) and atttempts no correction.
 }
+\examples{
+have_packages <- require("dplyr") && require("linelist")
+if (have_packages) { withAutoprint({
+
+# Simulating linelist data
+
+linelist     <- gen_data("Measles")
+measles_dict <- msf_dict("Measles", compact = FALSE) \%>\%
+  select(option_code, option_name, everything())
+
+# Cleaning linelist data
+linelist_clean <- clean_variable_spelling(
+  x = linelist,
+  wordlists = filter(measles_dict, !is.na(option_code)),
+  spelling_vars = "data_element_shortname",
+  sort_by = "option_order_in_set"
+)
+
+# get a descriptive table by sex
+descriptive(linelist_clean, "sex")
+
+# describe prenancy statistics, but remove missing data from the tally
+descriptive(linelist_clean, "trimester", explicit_missing = FALSE)
+
+# describe prenancy statistics, stratifying by vitamin A perscription
+descriptive(linelist_clean, "trimester", "prescribed_vitamin_a", explicit_missing = FALSE)
+
+
+}) }
+
+}

--- a/man/descriptive.Rd
+++ b/man/descriptive.Rd
@@ -5,9 +5,9 @@
 \alias{multi_descriptive}
 \title{Produces counts with respective proportions from specified variables in a dataframe.}
 \usage{
-descriptive(df, counter, grouper = NA, multiplier = 100, digits = 1,
-  proptotal = FALSE, coltotals = FALSE, rowtotals = FALSE,
-  single_row = FALSE, explicit_missing = TRUE)
+descriptive(df, counter, grouper = NULL, multiplier = 100,
+  digits = 1, proptotal = FALSE, coltotals = FALSE,
+  rowtotals = FALSE, single_row = FALSE, explicit_missing = TRUE)
 
 multi_descriptive(df, ..., multiplier = 100, digits = 1,
   proptotal = FALSE, coltotals = TRUE, .id = "symptom",

--- a/man/descriptive.Rd
+++ b/man/descriptive.Rd
@@ -41,7 +41,7 @@ to a single row so that variables can be concatenated into a data frame.
 Defaults to \code{FALSE}.}
 
 \item{explicit_missing}{if \code{TRUE}, missing values will be marked as
-\code{(Missing)} and tabulated. Defaults to \code{FALSE}, where missing values are
+\code{Missing} and tabulated. Defaults to \code{FALSE}, where missing values are
 excluded from the computation}
 
 \item{...}{columns to pass to descriptive}

--- a/man/descriptive.Rd
+++ b/man/descriptive.Rd
@@ -7,10 +7,11 @@
 \usage{
 descriptive(df, counter, grouper = NA, multiplier = 100, digits = 1,
   proptotal = FALSE, coltotals = FALSE, rowtotals = FALSE,
-  single_row = FALSE)
+  single_row = FALSE, explicit_missing = TRUE)
 
 multi_descriptive(df, ..., multiplier = 100, digits = 1,
-  proptotal = FALSE, coltotals = TRUE, .id = "symptom")
+  proptotal = FALSE, coltotals = TRUE, .id = "symptom",
+  explicit_missing = TRUE)
 }
 \arguments{
 \item{df}{A dataframe (e.g. your linelist)}
@@ -38,6 +39,10 @@ proportions for each column.}
 \item{single_row}{if \code{TRUE} and \code{grouper = NA}, then the output is flattened
 to a single row so that variables can be concatenated into a data frame.
 Defaults to \code{FALSE}.}
+
+\item{explicit_missing}{if \code{TRUE}, missing values will be marked as
+\code{(Missing)} and tabulated. Defaults to \code{FALSE}, where missing values are
+excluded from the computation}
 
 \item{...}{columns to pass to descriptive}
 

--- a/tests/testthat/test-descriptive.R
+++ b/tests/testthat/test-descriptive.R
@@ -1,0 +1,111 @@
+context('descriptive table tests')
+
+
+
+humans     <- dplyr::filter(dplyr::starwars, species == "Human")
+# table of hair color
+hair_table <- descriptive(humans, hair_color)
+# table of homeworld X eye color (homeworld is missing for 5 characters)
+home_eye   <- descriptive(humans, homeworld, eye_color)
+
+# as above, but percentages are proportional to whole data set
+phair_table <- descriptive(humans, hair_color, proptotal = TRUE)
+phome_eye   <- descriptive(humans, homeworld, eye_color, proptotal = TRUE)
+
+
+
+test_that("warnings are generated for missing data", {
+  
+  expect_warning({
+  phome_eye_m <- descriptive(humans, homeworld, eye_color, proptotal = TRUE, explicit_missing = FALSE)
+  }, "Removing 5 missing values")
+})
+
+
+
+
+test_that("descriptive returns a table of counts and proportions that sum to 100", {
+
+  skip_on_cran()
+
+  expect_is(hair_table, "tbl_df")
+  expect_named(hair_table, c('hair_color', 'n', 'prop'))
+  expect_equal(sum(hair_table$prop), 100)
+  expect_equal(sum(phair_table$prop), 100)
+  expect_equal(sum(hair_table$n), nrow(humans))
+  expect_equal(sum(phair_table$n), nrow(humans))
+
+  # can do NSE and quoted
+  hc <- "hair_color"
+  expect_identical(hair_table, descriptive(humans, hc))
+
+})
+
+
+test_that("descriptive will add rows and columns for totals", {
+
+  skip_on_cran()
+  hair_table_rc <- descriptive(humans, hair_color, coltotals = TRUE, rowtotals = TRUE)
+
+  # There will be an extra column
+  expect_named(hair_table_rc, c('hair_color', 'n', 'prop', 'Total'))
+
+  # The last row will be total
+  expect_identical(hair_table_rc$hair_color[nrow(hair_table_rc)], "Total")
+
+  # The sum of the tabulations plus total will be double of the tabulations
+  expect_identical(sum(hair_table_rc$n), sum(hair_table$n) * 2)
+
+  # The final row should be 100
+  expect_identical(hair_table_rc$prop[nrow(hair_table_rc)], 100)
+  
+  # The total will be the same as n for no grouping
+  expect_identical(hair_table_rc$n, hair_table_rc$Total)
+
+})
+
+
+
+
+test_that("descriptive can take a grouping factor", {
+
+  skip_on_cran()
+  expect_is(home_eye, "tbl_df")
+
+  expect_identical(as.character(home_eye$homeworld[nrow(home_eye)]), "Missing")
+
+  # The columns will be alphabetical if it's not a factor
+  the_columns <- sprintf(c("%s_n", "%s_prop"), rep(sort(unique(humans$eye_color)), each = 2))
+
+  expect_named(home_eye, c("homeworld", the_columns))
+
+  # all "n" should add up to the number of rows in the data set
+  expect_equal(sum(dplyr::select(home_eye, dplyr::ends_with("_n"))), nrow(humans)) 
+  expect_equal(sum(dplyr::select(phome_eye, dplyr::ends_with("_n"))), nrow(humans)) 
+  expect_equal(sum(dplyr::select(phome_eye_m, dplyr::ends_with("_n"))), nrow(humans) - 5) 
+
+  # all proportions should add up to 100 per column by default
+  expect_equivalent(colSums(dplyr::select(home_eye, dplyr::ends_with("_prop"))), rep(100, 6))
+  # overall if proptotal = TRUE
+  expect_equal(sum(colSums(dplyr::select(phome_eye, dplyr::ends_with("_prop")))), 100)
+  # missing data excluded does not affect the total
+  expect_equal(sum(colSums(dplyr::select(phome_eye_m, dplyr::ends_with("_prop")))), 100)
+
+})
+
+
+test_that("descriptive will respect ordering of the grouping factor", {
+
+  skip_on_cran()
+ 
+  hf <- humans %>% 
+    mutate(eye_color = forcats::fct_inorder(eye_color)) %>%
+    descriptive(homeworld, eye_color)
+
+  the_columns <- sprintf(c("%s_n", "%s_prop"), rep(unique(humans$eye_color), each = 2))
+
+  expect_named(hf, c("homeworld", the_columns))
+
+})
+
+

--- a/tests/testthat/test-descriptive.R
+++ b/tests/testthat/test-descriptive.R
@@ -16,9 +16,6 @@ phome_eye   <- descriptive(humans, homeworld, eye_color, proptotal = TRUE)
 
 test_that("warnings are generated for missing data", {
   
-  expect_warning({
-  phome_eye_m <- descriptive(humans, homeworld, eye_color, proptotal = TRUE, explicit_missing = FALSE)
-  }, "Removing 5 missing values")
 })
 
 
@@ -71,6 +68,9 @@ test_that("descriptive can take a grouping factor", {
 
   skip_on_cran()
   expect_is(home_eye, "tbl_df")
+  expect_warning({
+    phome_eye_m <- descriptive(humans, homeworld, eye_color, proptotal = TRUE, explicit_missing = FALSE)
+  }, "Removing 5 missing values")
 
   expect_identical(as.character(home_eye$homeworld[nrow(home_eye)]), "Missing")
 


### PR DESCRIPTION
 - remove rounding from calculations (this was causing proportions
   to not sum to 100%)
 - add explicit_missing argument
        - (huge) if TRUE, all NA data in the counts would be converted
          to "Missing"
        - if FALSE, all NA data in the counts would be removed.
 - all NA data in the grouper would be explicit by default
 - all outbreak templates were updated for this change
 - descriptive now gains documentation AND the ability to do non-standard evaluation!
 - tests have been added