### PR TITLE
Update tabulate_survey()

### DIFF
--- a/R/tabulate_survey.R
+++ b/R/tabulate_survey.R
@@ -48,7 +48,6 @@
 #'
 #' # stratified sample
 #' surv <- apistrat %>%
-#'   mutate(yrstuff = sprintf("%s_something_%s", yr.rnd, stype)) %>%
 #'   as_survey_design(strata = stype, weights = pw)
 #'
 #' s <- surv %>%

--- a/R/tabulate_survey.R
+++ b/R/tabulate_survey.R
@@ -185,7 +185,7 @@ tabulate_survey <- function(x, var, strata = NULL, pretty = TRUE, wide = TRUE,
     # @param st a symbol specifying the column for the stratifier
     # @return a data frame with five columns, the stratifier, the counter, 
     # proportion, lower, and upper.
-    sprop <- function(xx, .x, .y, cod, st) {
+    s_prop_strat <- function(xx, .x, .y, cod, st) {
       st  <- rlang::enquo(st)
       cod <- rlang::enquo(cod)
       res <- srvyr::summarise(xx, 
@@ -196,7 +196,7 @@ tabulate_survey <- function(x, var, strata = NULL, pretty = TRUE, wide = TRUE,
       dplyr::bind_cols(!! st := .y, res)
     }
   } else {
-    sprop <- function(xx, .x, cod) {
+    s_prop <- function(xx, .x, cod) {
       cod <- rlang::enquo(cod)
       res <- srvyr::summarise(xx, 
                               proportion = srvyr::survey_mean(!! cod == .x,
@@ -211,12 +211,12 @@ tabulate_survey <- function(x, var, strata = NULL, pretty = TRUE, wide = TRUE,
     yst <- dplyr::pull(y, !!  st)
     if (proptotal) {
       # map both the counter and stratifier to sprop
-      props <- purrr::map2_dfr(ycod, yst, ~sprop(xx, .x, .y, !! cod, !! st))
+      props <- purrr::map2_dfr(ycod, yst, ~s_prop_strat(xx, .x, .y, !! cod, !! st))
     } else {
       # group by the stratifier and then map the counter
       xx    <- srvyr::group_by(xx, !! st, .drop = FALSE)
       g     <- unique(ycod)
-      props <- purrr::map_dfr(g, ~sprop(xx, .x, !! cod))
+      props <- purrr::map_dfr(g, ~s_prop(xx, .x, !! cod))
     }
     # Make sure that the resulting columns are factors
     codl  <- levels(ycod)
@@ -228,7 +228,7 @@ tabulate_survey <- function(x, var, strata = NULL, pretty = TRUE, wide = TRUE,
     # no stratifier, just map the counter to sprop and make sure it's a factor
     xx    <- srvyr::ungroup(x)
     v     <- as.character(y[[1]])
-    props <- purrr::map_dfr(ycod, ~sprop(xx, .x, !! cod))
+    props <- purrr::map_dfr(ycod, ~s_prop(xx, .x, !! cod))
     codl  <- levels(dplyr::pull(y, !! cod))
     props <- dplyr::mutate(props, !! cod := factor(!! cod, levels = codl))
   }

--- a/R/tabulate_survey.R
+++ b/R/tabulate_survey.R
@@ -225,7 +225,7 @@ tabulate_survey <- function(x, var, strata = NULL, pretty = TRUE, wide = TRUE,
   # Join the data together
   y       <- y[!colnames(y) %in% "n_se"]
   join_by <- if (null_strata) names(y)[[1]] else names(y)[1:2]
-  y       <- left_join(y, props, by = join_by)
+  y       <- dplyr::left_join(y, props, by = join_by)
 
   if (coltotals) {
     if (null_strata) {
@@ -280,6 +280,7 @@ tabulate_survey <- function(x, var, strata = NULL, pretty = TRUE, wide = TRUE,
 #' @noRd
 prettify_tabulation <- function(y, digits = 1, null_strata, cod, st) {
 
+
   y <- unite_ci(y, "ci", dplyr::starts_with("proportion"), percent = TRUE, digits = digits)
 
   # convert any NA% proportions to just NA
@@ -328,6 +329,8 @@ widen_tabulation <- function(y, cod, st) {
   y$tmp <- forcats::fct_inorder(y$tmp)
 
   y <- tidyr::spread(y, "tmp", "value")
+
+  y <- dplyr::mutate_at(y, .vars = dplyr::vars(dplyr::ends_with(" n")), .funs = ~as.numeric(.))
 
 }
 

--- a/R/tabulate_survey.R
+++ b/R/tabulate_survey.R
@@ -117,13 +117,13 @@ tabulate_survey <- function(x, var, strata = NULL, pretty = TRUE, wide = TRUE,
   if (null_strata) {
     st <- st 
   } else {
-    if (vars[2] != names(surv$strata)[1]) {
+    if (vars[2] != names(x$strata)[1]) {
       msg <- paste("The stratification present in the survey object (%s) does",
                    "not match the user-specified stratification (%s). If you",
                    "want to assess the survey tabulation stratifying by '%s',",
                    "re-specify the survey object with this",
                    "strata and the appropriate weights.")
-      stop(sprintf(msg, names(surv$strata)[1], vars[2], vars[2]))
+      stop(sprintf(msg, names(x$strata)[1], vars[2], vars[2]))
     }
     st <- rlang::sym(vars[2])
   }

--- a/man/tabulate_survey.Rd
+++ b/man/tabulate_survey.Rd
@@ -65,9 +65,11 @@ library(survey)
 data(api)
 
 # stratified sample
-s <- apistrat \%>\%
-  as_survey_design(strata = stype, weights = pw) \%>\%
-  tabulate_survey(stype, awards, coltotals = TRUE, rowtotals = TRUE, deff = TRUE)
+surv <- apistrat \%>\%
+  as_survey_design(strata = stype, weights = pw)
+
+s <- surv \%>\%
+  tabulate_survey(awards, stype, coltotals = TRUE, rowtotals = TRUE, deff = TRUE)
 s
 
 # making things pretty
@@ -79,23 +81,19 @@ s \%>\%
                    "deff" = "Design Effect")
 
 # long data
-apistrat \%>\%
-  as_survey_design(strata = stype, weights = pw) \%>\%
-  tabulate_survey(stype, strata = awards, wide = FALSE)
+surv \%>\%
+  tabulate_survey(awards, strata = stype, wide = FALSE)
 
 # tabulate binary variables
-apistrat \%>\%
-  as_survey_design(strata = stype, weights = pw) \%>\%
+surv \%>\%
   tabulate_binary_survey(yr.rnd, sch.wide, awards, keep = c("Yes"))
 
 # stratify the binary variables
-apistrat \%>\%
-  as_survey_design(strata = stype, weights = pw) \%>\%
+surv \%>\%
   tabulate_binary_survey(yr.rnd, sch.wide, awards, strata = stype, keep = c("Yes"))
 
 # invert the tabulation
-apistrat \%>\%
-  as_survey_design(strata = stype, weights = pw) \%>\%
+surv \%>\%
   tabulate_binary_survey(yr.rnd, sch.wide, awards, keep = c("Yes"), deff = TRUE, invert = TRUE)
 }
 \seealso{

--- a/tests/testthat/test-tabulate_survey.R
+++ b/tests/testthat/test-tabulate_survey.R
@@ -5,16 +5,16 @@ s <- srvyr::as_survey_design(apistrat, strata = stype, weights = pw)
 
 # with out proptotal
 sa_crd_p  <- tabulate_survey(s,
-                             stype, 
                              awards,
+                             stype, 
                              coltotals = TRUE,
                              rowtotals = TRUE,
                              deff      = TRUE)
 
 # with proptotal
 sa_pcrd_p <- tabulate_survey(s,
-                             stype, 
                              awards,
+                             stype, 
                              proptotal = TRUE,
                              coltotals = TRUE,
                              rowtotals = TRUE,
@@ -24,22 +24,22 @@ test_that("tabulations return pretty results by default", {
   expect_is(sa_crd_p, "tbl_df")
   expect_is(sa_pcrd_p, "tbl_df")
 
-  expect_named(sa_crd_p, c('stype', 'No n', 'No ci', 'No deff', 
-                           'Yes n', 'Yes ci', 'Yes deff', 'Total n'))
+  expect_named(sa_crd_p, c("awards", "E n", "E ci", "E deff", "H n", "H ci", 
+                           "H deff", "M n", "M ci", "M deff", "Total n"))
   
-  expect_named(sa_pcrd_p, c('stype', 'No n', 'No ci', 'No deff', 
-                            'Yes n', 'Yes ci', 'Yes deff', 'Total n'))
+  expect_named(sa_pcrd_p, c("awards", "E n", "E ci", "E deff", "H n", "H ci", 
+                           "H deff", "M n", "M ci", "M deff", "Total n"))
 
-  expect_is(sa_crd_p$'No ci' , "character")
-  expect_is(sa_crd_p$'No n'  , "character")
+  expect_is(sa_crd_p$'E ci' , "character")
+  expect_is(sa_crd_p$'E n'  , "character")
 
-  expect_is(sa_pcrd_p$'No ci', "character")
-  expect_is(sa_pcrd_p$'No n' , "character")
+  expect_is(sa_pcrd_p$'E ci', "character")
+  expect_is(sa_pcrd_p$'E n' , "character")
 })
 
 no_proptot <- tabulate_survey(s,
-                              stype,
                               awards,
+                              stype,
                               proptotal = FALSE,
                               coltotals = FALSE,
                               rowtotals = FALSE,
@@ -48,8 +48,8 @@ no_proptot <- tabulate_survey(s,
                               deff      = TRUE)
 
 proptot <- tabulate_survey(s,
-                           stype,
                            awards,
+                           stype,
                            proptotal = TRUE,
                            coltotals = FALSE,
                            rowtotals = FALSE,
@@ -59,10 +59,10 @@ proptot <- tabulate_survey(s,
 
 test_that("Proportions are correct", {
 
-  expect_named(proptot, c('awards', 'stype', 'n', 'deff', 'proportion', 'proportion_lower', 'proportion_upper'))
-  expect_named(no_proptot, c('awards', 'stype', 'n', 'deff', 'proportion', 'proportion_lower', 'proportion_upper'))
+  expect_named(proptot, c('awards', 'stype', 'n', 'deff', 'proportion', 'proportion_low', 'proportion_upp'))
+  expect_named(no_proptot, c('awards', 'stype', 'n', 'deff', 'proportion', 'proportion_low', 'proportion_upp'))
   expect_equal(sum(proptot$proportion)   , 1)
-  expect_equal(sum(no_proptot$proportion), 2)
+  expect_equal(sum(no_proptot$proportion), 3)
 
 })
 


### PR DESCRIPTION
This updates the internals of the tabulate_survey() function to be more consistent and to actually work. 

There were some weird calculations going on:

```r
library(sitrep)
library(srvyr)
library(survey)

data(api)
apistrat %>%
  as_survey_design(strata = stype, weights = pw) %>%
  tabulate_survey(yr.rnd, strata = stype)
#> # A tibble: 2 x 7
#>   yr.rnd `E n` `E ci`          `H n` `H ci`            `M n` `M ci`        
#>   <fct>  <chr> <chr>           <chr> <chr>             <chr> <chr>         
#> 1 No     3625  77.4% (63.8--8… 740   100.0% (100.0--1… 977   95.7% (72.1--…
#> 2 Yes    796   22.6% (13.1--3… 15    0.0% (0.0--0.0)   41    4.3% (0.5--27…
```

Alex checked and things weren't quite right:

```r
 out <- apistrat %>% 
+   mutate(yr.rnd.bin = if_else(yr.rnd == "No", 1, 0), 
+          yr.rnd.wgt = yr.rnd.bin * pw)
> 
> 
> # calc denominator 
> denom <- out %>% 
+   group_by(stype) %>% 
+   summarise(
+     denom = sum(pw)
+   )
> 
> # get weighted counts for binary factor by strata
> counts <- out %>% 
+   group_by(stype, yr.rnd) %>% 
+   summarise(counts = sum(yr.rnd.wgt))
> 
> 
> # merge counts and denom 
> merged <- left_join(counts, denom, by = "stype")
> 
> 
> # calculate stratified props for factor levels 
> merged %>% 
+   mutate(wgtprop = counts/denom)
# A tibble: 6 x 5
# Groups:   stype [3]
  stype yr.rnd counts denom wgtprop
  <fct> <fct>   <dbl> <dbl>   <dbl>
1 E     No      3625. 4421.    0.82
2 E     Yes        0  4421.    0   
3 H     No       740.  755.    0.98
4 H     Yes        0   755.    0   
5 M     No       977. 1018.    0.96
6 M     Yes        0  1018.    0
```

After this refactor, it works:

``` r
library(sitrep)
library(srvyr)
#> 
#> Attaching package: 'srvyr'
#> The following object is masked from 'package:stats':
#> 
#>     filter
library(survey)
#> Loading required package: grid
#> Loading required package: Matrix
#> Loading required package: survival
#> 
#> Attaching package: 'survey'
#> The following object is masked from 'package:graphics':
#> 
#>     dotchart

data(api)
apistrat %>%
  as_survey_design(strata = stype, weights = pw) %>%
  tabulate_survey(yr.rnd, strata = stype, wide = TRUE)
#> # A tibble: 2 x 7
#>   yr.rnd `E n` `E ci`           `H n` `H ci`          `M n` `M ci`         
#>   <fct>  <dbl> <chr>            <dbl> <chr>           <dbl> <chr>          
#> 1 No     3625. 82.0% (73.1--88… 740.  98.0% (86.3--9… 977.  96.0% (84.7--9…
#> 2 Yes     796. 18.0% (11.6--26…  15.1 2.0% (0.3--13.…  40.7 4.0% (1.0--15.…
```

<sup>Created on 2019-06-24 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
