### PR TITLE
Simplify descriptive_table

### DIFF
--- a/tests/testthat/test-descriptive.R
+++ b/tests/testthat/test-descriptive.R
@@ -13,14 +13,6 @@ phair_table <- descriptive(humans, hair_color, proptotal = TRUE)
 phome_eye   <- descriptive(humans, homeworld, eye_color, proptotal = TRUE)
 
 
-
-test_that("warnings are generated for missing data", {
-  
-})
-
-
-
-
 test_that("descriptive returns a table of counts and proportions that sum to 100", {
 
   skip_on_cran()


### PR DESCRIPTION
This simplifies the counting by sprinkling `.drop = FALSE` and DRYing out the code. I've also added sections to make sure people know what the h\*ck is going on.

Background: in a commit far away, a temporary dummy level was added to the counter levels when counting with groups  so that `complete()` could fill in the counter for groups that were missing. 

Unfortunately, this was problematic with aweek objects since they needed valid aweek objects in order to be added. This circumvents the need for creating a dummy variable. 