### PR TITLE
add support for factors and numbers in descriptive

### DIFF
--- a/R/descriptive-table.R
+++ b/R/descriptive-table.R
@@ -89,7 +89,16 @@ descriptive <- function(df, counter, grouper = NULL, multiplier = 100, digits = 
   grouper   <- tidyselect::vars_select(colnames(df), !!enquo(grouper))
   sym_count <- rlang::sym(counter)
 
+  # Check if counter is an integer and force factor ----------------------------
+
+  if (is.numeric(df[[counter]])) {
+    message("converting numeric variable to factor")
+    df[[counter]] <- cut(df[[counter]], breaks = pretty(range(df[[counter]], na.rm = TRUE)))
+  }
   
+  if (is.logical(df[[counter]])) {
+    df[[counter]] <- factor(df[[counter]], levels = c("TRUE", "FALSE"))
+  }
   # Filter missing data --------------------------------------------------------
 
   if (explicit_missing) {

--- a/tests/testthat/test-descriptive.R
+++ b/tests/testthat/test-descriptive.R
@@ -30,6 +30,23 @@ test_that("descriptive returns a table of counts and proportions that sum to 100
 
 })
 
+test_that("descriptive will convert numbers to factors with cut", {
+
+  massive <- cut(humans$mass, breaks = pretty(range(humans$mass, na.rm = TRUE)))
+
+  expect_message(humass <- descriptive(humans, mass, gender), "converting numeric variable to factor")
+  expect_identical(levels(humass$mass), c(levels(massive), "Missing"))
+
+})
+
+
+test_that("descriptive will convert logicals to factors", {
+
+  humans$luke <- humans$name == "Luke Skywalker"
+  huluke <- descriptive(humans, luke, gender)
+  expect_identical(huluke$luke, factor(c(TRUE, FALSE), as.character(c(TRUE, FALSE))))
+
+})
 
 test_that("descriptive will add rows and columns for totals", {
 


### PR DESCRIPTION
if the user wants to describe a numeric or logical column, they should be able to do it. This adds support for that:

``` r
library(sitrep)
library(dplyr)
humans <- filter(dplyr::starwars, species == "Human")
humans$luke <- humans$name == "Luke Skywalker"
descriptive(humans, mass, gender) # descriptive for integers
#> converting numeric variable to factor
#> # A tibble: 6 x 5
#>   mass      female_n female_prop male_n male_prop
#>   <fct>        <dbl>       <dbl>  <dbl>     <dbl>
#> 1 (40,60]          2        22.2      0      0   
#> 2 (60,80]          1        11.1     11     42.3 
#> 3 (80,100]         0         0        5     19.2 
#> 4 (100,120]        0         0        2      7.69
#> 5 (120,140]        0         0        1      3.85
#> 6 Missing          6        66.7      7     26.9
descriptive(humans, luke, gender) # descriptive for logical
#> # A tibble: 2 x 5
#>   luke  female_n female_prop male_n male_prop
#>   <fct>    <dbl>       <dbl>  <dbl>     <dbl>
#> 1 TRUE         0           0      1      3.85
#> 2 FALSE        9         100     25     96.2
```

<sup>Created on 2019-06-28 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>