### PR TITLE
update zcurve to take a data frame

### DIFF
--- a/R/zcurve.R
+++ b/R/zcurve.R
@@ -31,9 +31,10 @@ zcurve <- function(x, zscore) {
   }
 
   ggplot(x) +
-    stat_density(aes(x = !! rlang::enquo(zscore), color = "observed"), geom = "line") +
-    stat_function(fun = stats::dnorm, 
-                  args = list(mean = 0, sd = 1),
+    stat_density(aes(x = !! rlang::enquo(zscore), color = "observed"), 
+                 geom = "line") +
+    stat_function(fun     = stats::dnorm,
+                  args    = list(mean = 0, sd = 1),
                   mapping = aes(color = "WHO standard")
                  ) +
     scale_color_manual("",

--- a/R/zcurve.R
+++ b/R/zcurve.R
@@ -1,6 +1,6 @@
 #' Create a curve comparing observed Z-scores to the WHO standard.
 #'
-#' @param dat a data frame
+#' @param x a data frame
 #' @param zscore bare name of a numeric vector containing computed zscores
 #' @return a ggplot2 object that is customisable via the ggplot2 package.
 #' @export
@@ -30,7 +30,7 @@ zcurve <- function(x, zscore) {
     stop("zscore must be a numeric variable")
   }
 
-  ggplot(dat) +
+  ggplot(x) +
     stat_density(aes(x = !! rlang::enquo(zscore), color = "observed"), geom = "line") +
     stat_function(fun = stats::dnorm, 
                   args = list(mean = 0, sd = 1),

--- a/R/zcurve.R
+++ b/R/zcurve.R
@@ -1,21 +1,37 @@
 #' Create a curve comparing observed Z-scores to the WHO standard.
 #'
-#' @param zscore a umeric vector containing computed zscores
+#' @param dat a data frame
+#' @param zscore bare name of a numeric vector containing computed zscores
 #' @return a ggplot2 object that is customisable via the ggplot2 package.
 #' @export
 #' @importFrom ggplot2 ggplot aes stat_function geom_density scale_x_continuous labs
 #' @examples
 #' library("ggplot2")
-#' dat <- rnorm(204) + runif(1) # slightly skewed
-#' zcurve(dat) +
+#' set.seed(9)
+#' dat <- data.frame(observed = rnorm(204) + runif(1),
+#'                   skewed   = rnorm(204) + runif(1, 0.5)
+#'                  ) # slightly skewed
+#' zcurve(dat, observed) +
 #'   labs(title = "Weight-for-Height Z-scores") +
 #'   theme_classic()
-zcurve <- function(zscore) {
+#'
+#' zcurve(dat, skewed) +
+#'   labs(title = "Weight-for-Height Z-scores") +
+#'   theme_classic()
+zcurve <- function(x, zscore) {
 
-  stopifnot(is.numeric(zscore))
-  dat <- data.frame(observed = zscore)
+  if (!is.data.frame(x)) {
+    stop("x must be a data frame")
+  }
+
+  zsc <- tidyselect::vars_pull(names(x), !! rlang::enquo(zscore))
+
+  if (!is.numeric(x[[zsc]])) {
+    stop("zscore must be a numeric variable")
+  }
+
   ggplot(dat) +
-    geom_density(aes(x = !!quote(observed), color = "observed")) +
+    stat_density(aes(x = !! rlang::enquo(zscore), color = "observed"), geom = "line") +
     stat_function(fun = stats::dnorm, 
                   args = list(mean = 0, sd = 1),
                   mapping = aes(color = "WHO standard")
@@ -27,7 +43,7 @@ zcurve <- function(zscore) {
     scale_x_continuous(limits = c(-6, 6)) + 
     labs(
          x = "Z-score",
-         y = sprintf("%% of cases\n(n = %d)", length(zscore))
+         y = sprintf("%% of cases\n(n = %d)", nrow(x))
     )
   
 }

--- a/inst/rmarkdown/templates/nutrition/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/nutrition/skeleton/skeleton.Rmd
@@ -829,8 +829,7 @@ zscore_results <- with(study_data_cleaned, anthro_prevalence(
 # only consider z-scores that are not flagged
 baseplot <- zscore_results %>% 
   filter(fwei == 0) %>% 
-  pull(zwei) %>% 
-  zcurve()
+  zcurve(zwei)
 
 baseplot + 
   scale_y_continuous(expand = c(0, 0))
@@ -969,9 +968,7 @@ dplyr::bind_cols(study_data_cleaned, muac) %>%
 # only include those not flagged
 zscore_results %>% 
   filter(flen == 0) %>% 
-  pull(zlen) %>% 
-  zcurve()
-
+  zcurve(zlen)
 
 # old 
 zcurve(zscore_results$zlen[zscore_results$flen == 0]) +

--- a/man/zcurve.Rd
+++ b/man/zcurve.Rd
@@ -7,9 +7,9 @@
 zcurve(x, zscore)
 }
 \arguments{
-\item{zscore}{bare name of a numeric vector containing computed zscores}
+\item{x}{a data frame}
 
-\item{dat}{a data frame}
+\item{zscore}{bare name of a numeric vector containing computed zscores}
 }
 \value{
 a ggplot2 object that is customisable via the ggplot2 package.

--- a/man/zcurve.Rd
+++ b/man/zcurve.Rd
@@ -4,10 +4,12 @@
 \alias{zcurve}
 \title{Create a curve comparing observed Z-scores to the WHO standard.}
 \usage{
-zcurve(zscore)
+zcurve(x, zscore)
 }
 \arguments{
-\item{zscore}{a umeric vector containing computed zscores}
+\item{zscore}{bare name of a numeric vector containing computed zscores}
+
+\item{dat}{a data frame}
 }
 \value{
 a ggplot2 object that is customisable via the ggplot2 package.
@@ -17,8 +19,15 @@ Create a curve comparing observed Z-scores to the WHO standard.
 }
 \examples{
 library("ggplot2")
-dat <- rnorm(204) + runif(1) # slightly skewed
-zcurve(dat) +
+set.seed(9)
+dat <- data.frame(observed = rnorm(204) + runif(1),
+                  skewed   = rnorm(204) + runif(1, 0.5)
+                 ) # slightly skewed
+zcurve(dat, observed) +
+  labs(title = "Weight-for-Height Z-scores") +
+  theme_classic()
+
+zcurve(dat, skewed) +
   labs(title = "Weight-for-Height Z-scores") +
   theme_classic()
 }

--- a/tests/testthat/test-zcurve.R
+++ b/tests/testthat/test-zcurve.R
@@ -1,7 +1,8 @@
 context("zcurve tests")
 set.seed(2019-01-15)
-dat <- rnorm(2974) - 0.4
-zc  <- zcurve(dat)
+z   <- rnorm(2974) - 0.4
+dat <- data.frame(zee = z)
+zc  <- zcurve(dat, zee)
 
 test_that("zcurve returns a ggplot2 object", {
   expect_is(zc, "ggplot")
@@ -12,5 +13,5 @@ test_that("zcurve data is equal to the number of observations", {
 })
 
 test_that("zcurve will throw an error if the input is not numeric", {
-  expect_error(zcurve(letters))
+  expect_error(zcurve(letters), "x must be a data frame")
 })


### PR DESCRIPTION
Hi @aspina7, this updates zcurve to take a data frame and then a vector:

``` r
library("sitrep")
library("ggplot2")
set.seed(9)
dat <- data.frame(observed = rnorm(204) + runif(1),
                  skewed   = rnorm(204) + runif(1, 0.5)
                 ) # slightly skewed
zcurve(dat, observed) +
  labs(title = "Weight-for-Height Z-scores") +
  theme_classic()
```

![](https://i.imgur.com/JSJSe68.png)

``` r

zcurve(dat, skewed) +
  labs(title = "Weight-for-Height Z-scores") +
  theme_classic()
```

![](https://i.imgur.com/UQzAAA3.png)

<sup>Created on 2019-07-02 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>