### PR TITLE
ignore hack_data directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.swp
 README.html
 inst/rmarkdown/templates/*/skeleton/*.xlsx
+inst/rmarkdown/hack_data/*


### PR DESCRIPTION
this ignores any files in the `inst/rmarkdown/hack_data` directory.

For example, I currently have all the data sets in there and my git status is clean:

```
$ du -h --summarize inst/rmarkdown/hack_data
19M	inst/rmarkdown/hack_data
```