### PR TITLE
Fix 140

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Imports:
     forcats,
     ggplot2,
     ggspatial,
+    glue,
     here,
     incidence,
     knitr,

--- a/R/tabulate_survey.R
+++ b/R/tabulate_survey.R
@@ -122,12 +122,15 @@ tabulate_survey <- function(x, var, strata = NULL, pretty = TRUE, wide = TRUE,
     st <- st 
   } else {
     if (vars[2] != names(x$strata)[1]) {
-      msg <- paste("The stratification present in the survey object (%s) does",
-                   "not match the user-specified stratification (%s). If you",
-                   "want to assess the survey tabulation stratifying by '%s',",
-                   "re-specify the survey object with this",
-                   "strata and the appropriate weights.")
-      stop(sprintf(msg, names(x$strata)[1], vars[2], vars[2]))
+      msg <- glue::glue(
+        "The stratification present in the survey object ({names(x$strata[1])})",
+        "does not match the user-specified stratification ({vars[2]}). If you",
+        "want to assess the survey tabulation stratifying by '{vars[2]}',",
+        "re-specify the survey object with this",
+        "strata and the appropriate weights.",
+        .sep = " "
+        )
+      stop(msg)
     }
     st <- rlang::sym(vars[2])
   }

--- a/R/tabulate_survey.R
+++ b/R/tabulate_survey.R
@@ -19,6 +19,10 @@
 #'
 #' @param method a method from [survey::svyciprop()] to calculate the confidence
 #'   interval. Defaults to "logit"
+#' 
+#' @param na.rm when `TRUE` (default), missing values in the categorical 
+#'   variable will be removed prior to calculations with a warning. `FALSE` will
+#'   not remove these missing values and may result in an error. 
 #'
 #' @param deff a logical indicating if the design effect should be reported.
 #'   Defaults to "TRUE"
@@ -78,7 +82,7 @@
 #' surv %>%
 #'   tabulate_binary_survey(yr.rnd, sch.wide, awards, keep = c("Yes"), deff = TRUE, invert = TRUE)
 tabulate_survey <- function(x, var, strata = NULL, pretty = TRUE, wide = TRUE,
-                            digits = 1, method = "logit", deff = FALSE,
+                            digits = 1, method = "logit", na.rm = TRUE, deff = FALSE,
                             proptotal = FALSE, rowtotals = FALSE, 
                             coltotals = FALSE) {
   stopifnot(inherits(x, "tbl_svy"))
@@ -128,6 +132,13 @@ tabulate_survey <- function(x, var, strata = NULL, pretty = TRUE, wide = TRUE,
   }
 
   x <- srvyr::select(x, !! cod, !!st)
+  if (na.rm) {
+    nas <- sum(is.na(x$variables[[vars[1]]]))
+    if (nas > 0) {
+      warning(sprintf("removing %s missing value(s)", nas))
+      x <- srvyr::filter(x, !is.na(!! cod))
+    }
+  }
 
   # here we are creating a dummy variable that is either the var or the
   # combination of var and strata so that we can get the right proportions from

--- a/R/tabulate_survey.R
+++ b/R/tabulate_survey.R
@@ -20,7 +20,7 @@
 #' @param method a method from [survey::svyciprop()] to calculate the confidence
 #'   interval. Defaults to "logit"
 #' 
-#' @param na.rm When `TRUE`, missing values present in `var` will be removed
+#' @param na.rm When `TRUE`, missing (NA) values present in `var` will be removed
 #'   from the data set with a warning, causing a change in denominator for the
 #'   tabulations.  The default is set to `FALSE`, which creates an explicit
 #'   missing value called "(Missing)".

--- a/inst/rmarkdown/templates/nutrition/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/nutrition/skeleton/skeleton.Rmd
@@ -530,10 +530,12 @@ study_data_cleaned <- bind_cols(study_data_cleaned, zscore_results)
 # * Severe acute malnutrition (SAM): WHZ score <-3 and/or oedema.
 study_data_cleaned <- study_data_cleaned %>% 
   mutate(
-    gam_whz = zwfl < -2 | oedema == "Yes", 
+    gam_whz = zwfl <  -2 | oedema == "Yes", 
     mam_whz = zwfl >= -3 & zwei < -2, 
-    sam_whz = zwfl < -3 |  oedema == "Yes"
-  )
+    sam_whz = zwfl <  -3 | oedema == "Yes"
+  ) %>%
+  mutate_at(.vars = vars(gam_whz, mam_whz, sam_whz), # mask flagged cases
+            .funs = ~if_else(!is.na(fwfl) & fwfl == 1, NA, .))
 
 
 # classify children according to muac 
@@ -546,7 +548,7 @@ study_data_cleaned <- study_data_cleaned %>%
 study_data_cleaned <- study_data_cleaned %>% 
   mutate(
     gam_muac = muac_mm_left_arm < 125 | oedema == "Yes", 
-    mam_muac = muac_mm_left_arm < 125 & muac_mm_left_arm >= 115 &  oedema == "No", 
+    mam_muac = muac_mm_left_arm < 125 & muac_mm_left_arm >= 115 & oedema == "No", 
     sam_muac = muac_mm_left_arm < 115 |  oedema == "Yes"
   )
 

--- a/man/tabulate_survey.Rd
+++ b/man/tabulate_survey.Rd
@@ -6,8 +6,8 @@
 \title{Tabulate survey design objects by a categorical and another stratifying variable}
 \usage{
 tabulate_survey(x, var, strata = NULL, pretty = TRUE, wide = TRUE,
-  digits = 1, method = "logit", deff = FALSE, proptotal = FALSE,
-  rowtotals = FALSE, coltotals = FALSE)
+  digits = 1, method = "logit", na.rm = TRUE, deff = FALSE,
+  proptotal = FALSE, rowtotals = FALSE, coltotals = FALSE)
 
 tabulate_binary_survey(x, ..., strata = NULL, proptotal = FALSE,
   keep = NULL, invert = FALSE, pretty = TRUE, wide = TRUE,
@@ -33,6 +33,10 @@ for proportion and CI}
 
 \item{method}{a method from \code{\link[survey:svyciprop]{survey::svyciprop()}} to calculate the confidence
 interval. Defaults to "logit"}
+
+\item{na.rm}{when \code{TRUE} (default), missing values in the categorical
+variable will be removed prior to calculations with a warning. \code{FALSE} will
+not remove these missing values and may result in an error.}
 
 \item{deff}{a logical indicating if the design effect should be reported.
 Defaults to "TRUE"}

--- a/man/tabulate_survey.Rd
+++ b/man/tabulate_survey.Rd
@@ -6,7 +6,7 @@
 \title{Tabulate survey design objects by a categorical and another stratifying variable}
 \usage{
 tabulate_survey(x, var, strata = NULL, pretty = TRUE, wide = TRUE,
-  digits = 1, method = "logit", na.rm = TRUE, deff = FALSE,
+  digits = 1, method = "logit", na.rm = FALSE, deff = FALSE,
   proptotal = FALSE, rowtotals = FALSE, coltotals = FALSE)
 
 tabulate_binary_survey(x, ..., strata = NULL, proptotal = FALSE,
@@ -34,9 +34,10 @@ for proportion and CI}
 \item{method}{a method from \code{\link[survey:svyciprop]{survey::svyciprop()}} to calculate the confidence
 interval. Defaults to "logit"}
 
-\item{na.rm}{when \code{TRUE} (default), missing values in the categorical
-variable will be removed prior to calculations with a warning. \code{FALSE} will
-not remove these missing values and may result in an error.}
+\item{na.rm}{When \code{TRUE}, missing values present in \code{var} will be removed
+from the data set with a warning, causing a change in denominator for the
+tabulations.  The default is set to \code{FALSE}, which creates an explicit
+missing value called "(Missing)".}
 
 \item{deff}{a logical indicating if the design effect should be reported.
 Defaults to "TRUE"}

--- a/tests/testthat/test-tabulate_survey.R
+++ b/tests/testthat/test-tabulate_survey.R
@@ -22,6 +22,12 @@ counts <- apistrat %>%
 # Default workflow
 s <- srvyr::as_survey_design(apistrat, strata = stype, weights = pw)
 
+# Adding in missing data
+aps            <- rbind(apistrat, NA)
+aps$pw[201]    <- aps$pw[200]
+aps$stype[201] <- aps$stype[200]
+sm             <- srvyr::as_survey_design(aps, strata = stype, weights = pw)
+
 # with the above example
 yr_rnd <- tabulate_survey(s, yr.rnd, stype, wide = FALSE, pretty = FALSE)
 
@@ -44,7 +50,6 @@ sa_pcrd_p <- tabulate_survey(s,
 
 
 
-
 # Testing ----------------------------------------------------------------------
 
 test_that("manual calculation matches ours", {
@@ -54,6 +59,15 @@ test_that("manual calculation matches ours", {
 
 })
 
+test_that("a warning is thrown for missing data", {
+                             
+  expect_warning(miss <- tabulate_survey(sm, yr.rnd, stype, wide = FALSE, pretty = FALSE),
+                 "removing 1 missing value(s)", fixed = TRUE)                             
+  # when comparing to known data, it's identical
+  expect_identical(miss$n, yr_rnd$n)
+  expect_identical(miss$proportion, yr_rnd$proportion)
+
+})
 
 test_that("tabulate_survey will throw an error if the stratification is not correct", {
   

--- a/tests/testthat/test-tabulate_survey.R
+++ b/tests/testthat/test-tabulate_survey.R
@@ -109,13 +109,12 @@ test_that("a warning is thrown for missing data", {
 
 test_that("tabulate_survey will throw an error if the stratification is not correct", {
   
-  msg <- paste("The stratification present in the survey object \\(%s\\) does",
-               "not match the user-specified stratification \\(%s\\). If you",
-               "want to assess the survey tabulation stratifying by '%s',",
+  msg <- paste("The stratification present in the survey object (stype) does",
+               "not match the user-specified stratification (awards). If you",
+               "want to assess the survey tabulation stratifying by 'awards',",
                "re-specify the survey object with this",
                "strata and the appropriate weights.")
-  expected <- sprintf(msg, "stype", "awards", "awards")
-  expect_error(tabulate_survey(s, stype, awards), expected)
+  expect_error(tabulate_survey(s, stype, awards), msg, fixed = TRUE)
   
 })
 


### PR DESCRIPTION
This will partially address #140. I think addressing #139 will be for another PR, but this will avoid the need for filtering. 


All in all, the fix was two things:

1. mask the flagged cases
2. drop missing entries in the var column 

and it only took two days to figure this out :weary: 

#### Edit

Here's an example of how the different options work:

``` r
suppressPackageStartupMessages({
  library("sitrep")
  library("dplyr")
  library("srvyr")
})
data('api', package = 'survey')


# Default workflow
s <- srvyr::as_survey_design(apistrat, strata = stype, weights = pw)

# Adding in missing data
aps            <- rbind(apistrat, NA)
aps$pw[201]    <- aps$pw[200]
aps$stype[201] <- aps$stype[200]
sm             <- srvyr::as_survey_design(aps, strata = stype, weights = pw)
sm2            <- srvyr::as_survey_design(aps, strata = stype, weights = pw)

# what we expect
tabulate_survey(s, yr.rnd, stype, wide = FALSE, pretty = FALSE)
#> # A tibble: 6 x 6
#>   yr.rnd stype      n proportion proportion_low proportion_upp
#>   <fct>  <fct>  <dbl>      <dbl>          <dbl>          <dbl>
#> 1 No     E     3625.      0.82          0.731            0.884
#> 2 No     H      740.      0.980         0.863            0.997
#> 3 No     M      977.      0.960         0.847            0.990
#> 4 Yes    E      796.      0.18          0.116            0.269
#> 5 Yes    H       15.1     0.0200        0.00262          0.137
#> 6 Yes    M       40.7     0.04          0.00954          0.153

# what we get with dropping missing values
tabulate_survey(sm, yr.rnd, stype, wide = FALSE, pretty = FALSE, na.rm = TRUE)
#> Warning in tabulate_survey(sm, yr.rnd, stype, wide = FALSE, pretty =
#> FALSE, : removing 1 missing value(s) from `yr.rnd`
#> # A tibble: 6 x 6
#>   yr.rnd stype      n proportion proportion_low proportion_upp
#>   <fct>  <fct>  <dbl>      <dbl>          <dbl>          <dbl>
#> 1 No     E     3625.      0.82          0.731            0.884
#> 2 No     H      740.      0.980         0.863            0.997
#> 3 No     M      977.      0.960         0.847            0.990
#> 4 Yes    E      796.      0.18          0.116            0.269
#> 5 Yes    H       15.1     0.0200        0.00262          0.137
#> 6 Yes    M       40.7     0.04          0.00954          0.153

# what we get with explicit missing values
m <- tabulate_survey(sm2, yr.rnd, stype, wide = FALSE, pretty = FALSE, na.rm = FALSE)
# showing the common vars
head(m)
#> # A tibble: 6 x 6
#>   yr.rnd stype      n proportion proportion_low proportion_upp
#>   <fct>  <fct>  <dbl>      <dbl>          <dbl>          <dbl>
#> 1 No     E     3625.      0.82          0.731            0.884
#> 2 No     H      740.      0.961         0.850            0.991
#> 3 No     M      977.      0.960         0.847            0.990
#> 4 Yes    E      796.      0.18          0.116            0.269
#> 5 Yes    H       15.1     0.0196        0.00257          0.134
#> 6 Yes    M       40.7     0.04          0.00954          0.153
# with the missing vars
m
#> # A tibble: 9 x 6
#>   yr.rnd    stype      n proportion proportion_low proportion_upp
#>   <fct>     <fct>  <dbl>      <dbl>          <dbl>          <dbl>
#> 1 No        E     3625.    8.20e- 1       7.31e- 1       8.84e- 1
#> 2 No        H      740.    9.61e- 1       8.50e- 1       9.91e- 1
#> 3 No        M      977.    9.60e- 1       8.47e- 1       9.90e- 1
#> 4 Yes       E      796.    1.80e- 1       1.16e- 1       2.69e- 1
#> 5 Yes       H       15.1   1.96e- 2       2.57e- 3       1.34e- 1
#> 6 Yes       M       40.7   4.00e- 2       9.54e- 3       1.53e- 1
#> 7 (Missing) E        0     2.90e-12       2.90e-12       2.90e-12
#> 8 (Missing) H       15.1   1.96e- 2       2.57e- 3       1.34e- 1
#> 9 (Missing) M        0     2.90e-12       2.90e-12       2.90e-12
```

<sup>Created on 2019-07-17 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

Comparing the tables, you can see that the "H" proportions are different based on dropping or including missing data. 