### PR TITLE
add conversion of factors and numerics

### DIFF
--- a/R/tabulate_survey.R
+++ b/R/tabulate_survey.R
@@ -137,6 +137,17 @@ tabulate_survey <- function(x, var, strata = NULL, pretty = TRUE, wide = TRUE,
 
   x <- srvyr::select(x, !! cod, !!st)
 
+  # If the counter variable is numeric or logical, we need to convert it to a
+  # factor. For logical variables, this is trivial, so we just do it.
+  if (is.logical(x$variables[[vars[1]]])) {
+    x <- srvyr::mutate(x, !! cod := factor(!! cod, levels = c("TRUE", "FALSE")))
+  }
+  # For numeric data, however, we need to warn the user
+  if (is.numeric(x$variables[[vars[1]]])) {
+    warning(glue::glue("converting `{vars[1]}` to a factor"))
+    x <- srvyr::mutate(x, !! cod := cut(!! cod, breaks = pretty(range(!! cod, na.rm = TRUE)), include.lowest = TRUE))
+  }
+
   # if there is missing data, we should treat it by either removing the rows
   # with the missing values or making the missing explicit.
   if (na.rm) {

--- a/tests/testthat/test-tabulate_survey.R
+++ b/tests/testthat/test-tabulate_survey.R
@@ -60,6 +60,42 @@ test_that("manual calculation matches ours", {
 
 })
 
+test_that("numeric data are converted to factors", {
+
+  expect_warning(pct <- tabulate_survey(s, pcttest), 
+                 "converting `pcttest` to a factor", fixed = TRUE)
+
+  pcf <- cut(apistrat$pcttest, 
+             breaks = pretty(range(apistrat$pcttest, na.rm = TRUE)), 
+             include.lowest = TRUE)
+
+  expect_identical(levels(pct$pcttest), levels(pcf))
+
+})
+
+
+test_that("character data works", {
+
+  char <- s %>%
+    mutate(yr = as.character(yr.rnd)) %>%
+    tabulate_survey(yr, stype, wide = FALSE, pretty = FALSE)
+
+  names(char)[1] <- "yr.rnd"
+  expect_identical(char, yr_rnd)
+
+})
+
+test_that("logical data are converted to factors", {
+
+  summer <- s %>%
+    mutate(summer = yr.rnd == "No") %>%
+    tabulate_survey(summer, stype, wide = FALSE, pretty = FALSE)
+
+  expect_identical(summer[-1], yr_rnd[-1])
+  expect_equal(levels(summer[[1]]), c("TRUE", "FALSE"))
+
+})
+
 test_that("a warning is thrown for missing data", {
 
   # na.rm = TRUE: WARNING ----------------------


### PR DESCRIPTION
this will fix #139

``` r
library("sitrep")
library("dplyr")
library("srvyr")
data('api', package = 'survey')


# Default workflow
s <- srvyr::as_survey_design(apistrat, strata = stype, weights = pw)

# with logical values
s %>%
  mutate(summer = yr.rnd == "No") %>%
  tabulate_survey(summer, stype, wide = FALSE, pretty = TRUE)
#> # A tibble: 6 x 4
#>   summer stype      n ci                
#>   <fct>  <fct>  <dbl> <chr>             
#> 1 TRUE   E     3625.  82.0% (73.1--88.4)
#> 2 TRUE   H      740.  98.0% (86.3--99.7)
#> 3 TRUE   M      977.  96.0% (84.7--99.0)
#> 4 FALSE  E      796.  18.0% (11.6--26.9)
#> 5 FALSE  H       15.1 2.0% (0.3--13.7)  
#> 6 FALSE  M       40.7 4.0% (1.0--15.3)

# with numeric values
# Note: not including the stratifier here because it gets hairy
tabulate_survey(s, pcttest, wide = FALSE, pretty = TRUE)
#> Warning in tabulate_survey(s, pcttest, wide = FALSE, pretty = TRUE):
#> converting `pcttest` to a factor
#> Warning: glm.fit: algorithm did not converge
#> # A tibble: 7 x 3
#>   pcttest       n ci                
#>   <fct>     <dbl> <chr>             
#> 1 [65,70]    20.4 0.3% (0.0--2.3)   
#> 2 (70,75]     0   0.0% (0.0--0.0)   
#> 3 (75,80]    15.1 0.2% (0.0--1.7)   
#> 4 (80,85]    44.2 0.7% (0.1--5.0)   
#> 5 (85,90]   184.  3.0% (1.4--6.4)   
#> 6 (90,95]   190.  3.1% (1.4--6.6)   
#> 7 (95,100] 5741.  92.7% (88.2--95.6)

# with character values
s %>%
  mutate(yr = as.character(yr.rnd)) %>%
  tabulate_survey(yr, stype, wide = FALSE, pretty = TRUE)
#> # A tibble: 6 x 4
#>   yr    stype      n ci                
#>   <fct> <fct>  <dbl> <chr>             
#> 1 No    E     3625.  82.0% (73.1--88.4)
#> 2 No    H      740.  98.0% (86.3--99.7)
#> 3 No    M      977.  96.0% (84.7--99.0)
#> 4 Yes   E      796.  18.0% (11.6--26.9)
#> 5 Yes   H       15.1 2.0% (0.3--13.7)  
#> 6 Yes   M       40.7 4.0% (1.0--15.3)
```

<sup>Created on 2019-07-17 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>