### PR TITLE
standardize numeric conversion in tabulation funs

### DIFF
--- a/R/descriptive-table.R
+++ b/R/descriptive-table.R
@@ -92,8 +92,8 @@ descriptive <- function(df, counter, grouper = NULL, multiplier = 100, digits = 
   # Check if counter is an integer and force factor ----------------------------
 
   if (is.numeric(df[[counter]])) {
-    message("converting numeric variable to factor")
-    df[[counter]] <- cut(df[[counter]], breaks = pretty(range(df[[counter]], na.rm = TRUE)))
+    warning(glue::glue("converting `{counter}` to a factor"))
+    df[[counter]] <- fac_from_num(df[[counter]])
   }
   
   if (is.logical(df[[counter]])) {

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -13,3 +13,26 @@ splice_df <- function(x, ...) {
     rlang::quo(`[[`(!!expr, !!col_name))
   })
 }
+
+
+# This will convert numbers to factors.
+#
+# If the number of unique numbers is five or fewer, then they will simply
+# be converted to factors in order, otherwise, they will be passed to cut and
+# pretty, preserving the lowest value. 
+#
+fac_from_num <- function(x) {
+  # count the number of unique numbers
+  udc <- sort(unique(x))
+  udc <- as.character(udc)
+
+  if (length(udc) < 6) {
+    x <- factor(as.character(x), levels = udc)
+  } else {
+    x <- cut(x, 
+             breaks = pretty(range(x, na.rm = TRUE)),
+             include.lowest = TRUE
+             )
+  }
+  x
+}

--- a/R/tabulate_survey.R
+++ b/R/tabulate_survey.R
@@ -145,7 +145,7 @@ tabulate_survey <- function(x, var, strata = NULL, pretty = TRUE, wide = TRUE,
   # For numeric data, however, we need to warn the user
   if (is.numeric(x$variables[[vars[1]]])) {
     warning(glue::glue("converting `{vars[1]}` to a factor"))
-    x <- srvyr::mutate(x, !! cod := cut(!! cod, breaks = pretty(range(!! cod, na.rm = TRUE)), include.lowest = TRUE))
+    x <- srvyr::mutate(x, !! cod := fac_from_num(!! cod))
   }
 
   # if there is missing data, we should treat it by either removing the rows

--- a/tests/testthat/test-descriptive.R
+++ b/tests/testthat/test-descriptive.R
@@ -12,6 +12,29 @@ home_eye   <- descriptive(humans, homeworld, eye_color)
 phair_table <- descriptive(humans, hair_color, proptotal = TRUE)
 phome_eye   <- descriptive(humans, homeworld, eye_color, proptotal = TRUE)
 
+test_that("descriptive doesn't force zero counts to missing for binary", {
+
+  onezero <- data.frame(x = c(1, 0, 0, 1, NA))
+  expect_warning(res <- descriptive(onezero, x),
+                 "converting `x` to a factor", fixed = TRUE)
+  expect_equal(nrow(res), 3)
+  expect_equal(res$n, c(2, 2, 1))
+  expect_equivalent(res$x, forcats::fct_inorder(c("0", "1", "Missing")))
+
+})
+
+
+test_that("descriptive doesn't use cut for five categories", { 
+
+  onezero <- data.frame(x = c(1, 0, 0, 1, NA, 42, 37, 341))
+  expect_warning(res <- descriptive(onezero, x),
+                 "converting `x` to a factor", fixed = TRUE)
+  expect_equal(nrow(res), 6)
+  expect_equal(res$n, c(2, 2, 1, 1, 1, 1))
+  expect_equivalent(res$x, forcats::fct_inorder(c("0", "1", "37", "42", "341", "Missing")))
+
+})
+
 
 test_that("descriptive returns a table of counts and proportions that sum to 100", {
 
@@ -32,9 +55,12 @@ test_that("descriptive returns a table of counts and proportions that sum to 100
 
 test_that("descriptive will convert numbers to factors with cut", {
 
-  massive <- cut(humans$mass, breaks = pretty(range(humans$mass, na.rm = TRUE)))
+  massive <- cut(humans$mass, 
+                 breaks = pretty(range(humans$mass, na.rm = TRUE)), 
+                 include.lowest = TRUE)
 
-  expect_message(humass <- descriptive(humans, mass, gender), "converting numeric variable to factor")
+  expect_warning(humass <- descriptive(humans, mass, gender), 
+                 "converting `mass` to a factor", fixed = TRUE)
   expect_identical(levels(humass$mass), c(levels(massive), "Missing"))
 
 })

--- a/tests/testthat/test-tabulate_survey.R
+++ b/tests/testthat/test-tabulate_survey.R
@@ -96,6 +96,19 @@ test_that("logical data are converted to factors", {
 
 })
 
+test_that("integer categorical data are converted to factors", {
+
+  expect_warning({
+  summer <- s %>%
+    mutate(summer = as.integer(yr.rnd == "Yes")) %>%
+    tabulate_survey(summer, stype, wide = FALSE, pretty = FALSE)
+  }, "converting `summer` to a factor", fixed = TRUE)
+
+  expect_identical(summer[-1], yr_rnd[-1])
+  expect_equal(levels(summer[[1]]), c("0", "1"))
+
+})
+
 test_that("a warning is thrown for missing data", {
 
   # na.rm = TRUE: WARNING ----------------------


### PR DESCRIPTION
this will fix #148 and partially address #144

I've added a new function that will convert factors from numbers, using cut when there are more than five unique numbers (not including NA)

``` r
library("sitrep")
d <- data.frame(x = c(1, 2, 3, 4, 5, NA))
descriptive(d, x)
#> Warning in descriptive(d, x): converting `x` to a factor
#> # A tibble: 6 x 3
#>   x           n  prop
#>   <fct>   <dbl> <dbl>
#> 1 1           1  16.7
#> 2 2           1  16.7
#> 3 3           1  16.7
#> 4 4           1  16.7
#> 5 5           1  16.7
#> 6 Missing     1  16.7
```

<sup>Created on 2019-07-18 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>