### PR TITLE
first stab at transposition

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -21,6 +21,12 @@ splice_df <- function(x, ...) {
 # be converted to factors in order, otherwise, they will be passed to cut and
 # pretty, preserving the lowest value. 
 #
+#' create factors from numbers
+#'
+#' @param x a vector of integers or numerics
+#'
+#' @noRd
+#' @return a factor
 fac_from_num <- function(x) {
   # count the number of unique numbers
   udc <- sort(unique(x))

--- a/R/tabulate_survey.R
+++ b/R/tabulate_survey.R
@@ -398,6 +398,9 @@ widen_tabulation <- function(y, cod, st, pretty = TRUE, digits = 1) {
 #' @param ... binary variables for tabulation
 #' @param keep a vector of binary values to keep
 #' @param invert if `TRUE`, the kept values are rejected. Defaults to `FALSE`
+#' @param transpose if `TRUE` and `strata` is not `NULL`, then the data are
+#'   transposed such that the `strata` is in rows and the variables are in
+#'   columns.
 #'
 tabulate_binary_survey <- function(x, ..., strata = NULL, proptotal = FALSE,
                                    keep = NULL, invert = FALSE, pretty = TRUE,

--- a/inst/rmarkdown/templates/nutrition/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/nutrition/skeleton/skeleton.Rmd
@@ -1121,7 +1121,9 @@ study_data_cleaned %>%
 ```{r}
 
 survey_design %>% 
-tabulate_binary_survey(indicators[1:3], strata = age_group, keep = TRUE)
+  tabulate_binary_survey(indicators[1:3], strata = age_group, keep = TRUE,
+                         transpose = "variable") %>%
+  knitr::kable(digits = 1)
 
 
 ```

--- a/man/tabulate_survey.Rd
+++ b/man/tabulate_survey.Rd
@@ -11,7 +11,7 @@ tabulate_survey(x, var, strata = NULL, pretty = TRUE, wide = TRUE,
 
 tabulate_binary_survey(x, ..., strata = NULL, proptotal = FALSE,
   keep = NULL, invert = FALSE, pretty = TRUE, wide = TRUE,
-  digits = 1, method = "logit", deff = FALSE, transpose = FALSE)
+  digits = 1, method = "logit", deff = FALSE, transpose = NULL)
 }
 \arguments{
 \item{x}{a survey design object}
@@ -58,9 +58,20 @@ created.}
 
 \item{invert}{if \code{TRUE}, the kept values are rejected. Defaults to \code{FALSE}}
 
-\item{transpose}{if \code{TRUE} and \code{strata} is not \code{NULL}, then the data are
-transposed such that the \code{strata} is in rows and the variables are in
-columns.}
+\item{transpose}{if strata is not \code{NULL} and \code{wide = TRUE}, then this will
+transpose the columns to the rows, which is useful when you stratify by
+age group. Default is \code{NULL}, which will not transpose anything. You have
+three options for transpose:
+\itemize{
+\item \code{transpose = "variable"}: uses the variable column, dropping values.
+Use this if you know that your values are all identical or at least
+identifiable by the variable name.
+\item \code{transpose = "value"}   : uses the value column, dropping variables.
+Use this if your values are important and the variable names are
+generic placeholders.
+\item \code{transpose = "both"}    : combines the variable and value columns.
+Use this if both the variables and values are important.
+}}
 }
 \value{
 a long or wide tibble with tabulations n, ci, and deff

--- a/man/tabulate_survey.Rd
+++ b/man/tabulate_survey.Rd
@@ -11,7 +11,7 @@ tabulate_survey(x, var, strata = NULL, pretty = TRUE, wide = TRUE,
 
 tabulate_binary_survey(x, ..., strata = NULL, proptotal = FALSE,
   keep = NULL, invert = FALSE, pretty = TRUE, wide = TRUE,
-  digits = 1, method = "logit", deff = FALSE)
+  digits = 1, method = "logit", deff = FALSE, transpose = FALSE)
 }
 \arguments{
 \item{x}{a survey design object}
@@ -57,6 +57,10 @@ created.}
 \item{keep}{a vector of binary values to keep}
 
 \item{invert}{if \code{TRUE}, the kept values are rejected. Defaults to \code{FALSE}}
+
+\item{transpose}{if \code{TRUE} and \code{strata} is not \code{NULL}, then the data are
+transposed such that the \code{strata} is in rows and the variables are in
+columns.}
 }
 \value{
 a long or wide tibble with tabulations n, ci, and deff

--- a/tests/testthat/test-tabulate_survey.R
+++ b/tests/testthat/test-tabulate_survey.R
@@ -214,6 +214,12 @@ test_that("Proportions are correct", {
 })
 
 
+
+
+# tabulate_binary_survey tests -------------------------------------------------
+
+
+
 test_that("tabulate_binary_survey needs a 'keep' argument", {
 
   expect_error({
@@ -254,5 +260,62 @@ test_that("tabulate_binary_survey returns complementary proportions", {
   expect_equal(bin_tot$proportion + bin_inv$proportion, c(1,    1,    1))
   expect_equal(bin_tot$n          + bin_inv$n,          c(6194, 6194, 6194))
   expect_equal(bin_tot$deff,                            bin_inv$deff)
+
+})
+
+
+test_that("transposition doesn't happen without strata", {
+
+  bin_trn <- tabulate_binary_survey(s,
+                                    awards,
+                                    yr.rnd,
+                                    sch.wide,
+                                    proptotal = TRUE,
+                                    pretty    = FALSE,
+                                    deff      = TRUE,
+                                    wide      = TRUE,
+                                    transpose = "variable",
+                                    keep      = "Yes")
+  
+  expect_identical(bin_trn, bin_tot)
+
+})
+
+
+test_that("values are sensible in a transposition", {
+
+  
+  bin_trn <- tabulate_binary_survey(s,
+                                    awards,
+                                    yr.rnd,
+                                    sch.wide,
+                                    strata    = stype,
+                                    proptotal = TRUE,
+                                    pretty    = FALSE,
+                                    deff      = TRUE,
+                                    wide      = TRUE,
+                                    transpose = "variable",
+                                    keep      = "Yes")
+  bin_str <- tabulate_binary_survey(s,
+                                    awards,
+                                    yr.rnd,
+                                    sch.wide,
+                                    strata    = stype,
+                                    proptotal = TRUE,
+                                    pretty    = FALSE,
+                                    deff      = TRUE,
+                                    wide      = TRUE,
+                                    transpose = NULL,
+                                    keep      = "Yes")
+
+  trn_props <- bin_trn[grepl("proportion", names(bin_trn))]
+  str_props <- bin_str[grepl("proportion", names(bin_str))]
+
+  # The tables are not equal
+  expect_failure(expect_equal(trn_props, str_props))
+  # Their names don't match
+  expect_failure(expect_named(trn_props, str_props))
+  # but they do sum to the same value
+  expect_equal(sum(trn_props), sum(str_props))
 
 })


### PR DESCRIPTION
This implements a transpose argument which takes the values NULL, "variable", "value" or "both". It will only work if the table is wide and has strata. 

``` r
  
library("sitrep")
library("srvyr")
#> 
#> Attaching package: 'srvyr'
#> The following object is masked from 'package:stats':
#> 
#>     filter

data('api', package = 'survey')
s <- srvyr::as_survey_design(apistrat, strata = stype, weights = pw)
# without transposition
tabulate_binary_survey(s,
                       awards,
                       yr.rnd,
                       sch.wide,
                       comp.imp,
                       strata    = stype,
                       transpose = NULL,
                       keep      = "Yes") %>%
knitr::kable(digits = 1, format.args = list(big.mark = ","))
```

<table>
<thead>
<tr class="header">
<th style="text-align: left;">variable</th>
<th style="text-align: left;">value</th>
<th style="text-align: right;">E n</th>
<th style="text-align: left;">E ci</th>
<th style="text-align: right;">H n</th>
<th style="text-align: left;">H ci</th>
<th style="text-align: right;">M n</th>
<th style="text-align: left;">M ci</th>
</tr>
</thead>
<tbody>
<tr class="odd">
<td style="text-align: left;">awards</td>
<td style="text-align: left;">Yes</td>
<td style="text-align: right;">3,227.3</td>
<td style="text-align: left;">73.0% (63.3–80.9)</td>
<td style="text-align: right;">241.6</td>
<td style="text-align: left;">32.0% (20.3–46.5)</td>
<td style="text-align: right;">488.6</td>
<td style="text-align: left;">48.0% (34.2–62.1)</td>
</tr>
<tr class="even">
<td style="text-align: left;">yr.rnd</td>
<td style="text-align: left;">Yes</td>
<td style="text-align: right;">795.8</td>
<td style="text-align: left;">18.0% (11.6–26.9)</td>
<td style="text-align: right;">15.1</td>
<td style="text-align: left;">2.0% (0.3–13.7)</td>
<td style="text-align: right;">40.7</td>
<td style="text-align: left;">4.0% (1.0–15.3)</td>
</tr>
<tr class="odd">
<td style="text-align: left;">sch.wide</td>
<td style="text-align: left;">Yes</td>
<td style="text-align: right;">4,023.1</td>
<td style="text-align: left;">91.0% (83.4–95.3)</td>
<td style="text-align: right;">392.6</td>
<td style="text-align: left;">52.0% (37.9–65.8)</td>
<td style="text-align: right;">712.6</td>
<td style="text-align: left;">70.0% (55.5–81.4)</td>
</tr>
<tr class="even">
<td style="text-align: left;">comp.imp</td>
<td style="text-align: left;">Yes</td>
<td style="text-align: right;">3,315.7</td>
<td style="text-align: left;">75.0% (65.4–82.6)</td>
<td style="text-align: right;">256.7</td>
<td style="text-align: left;">34.0% (21.9–48.6)</td>
<td style="text-align: right;">488.6</td>
<td style="text-align: left;">48.0% (34.2–62.1)</td>
</tr>
</tbody>
</table>

``` r
# with transposition
tabulate_binary_survey(s,
                       awards,
                       yr.rnd,
                       sch.wide,
                       comp.imp,
                       strata    = stype,
                       transpose = "variable",
                       keep      = "Yes") %>%
knitr::kable(digits = 1, format.args = list(big.mark = ","))
```

<table>
<thead>
<tr class="header">
<th style="text-align: left;">stype</th>
<th style="text-align: right;">awards n</th>
<th style="text-align: left;">awards ci</th>
<th style="text-align: right;">comp.imp n</th>
<th style="text-align: left;">comp.imp ci</th>
<th style="text-align: right;">sch.wide n</th>
<th style="text-align: left;">sch.wide ci</th>
<th style="text-align: right;">yr.rnd n</th>
<th style="text-align: left;">yr.rnd ci</th>
</tr>
</thead>
<tbody>
<tr class="odd">
<td style="text-align: left;">E</td>
<td style="text-align: right;">3,227.3</td>
<td style="text-align: left;">73.0% (63.3–80.9)</td>
<td style="text-align: right;">3,315.7</td>
<td style="text-align: left;">75.0% (65.4–82.6)</td>
<td style="text-align: right;">4,023.1</td>
<td style="text-align: left;">91.0% (83.4–95.3)</td>
<td style="text-align: right;">795.8</td>
<td style="text-align: left;">18.0% (11.6–26.9)</td>
</tr>
<tr class="even">
<td style="text-align: left;">H</td>
<td style="text-align: right;">241.6</td>
<td style="text-align: left;">32.0% (20.3–46.5)</td>
<td style="text-align: right;">256.7</td>
<td style="text-align: left;">34.0% (21.9–48.6)</td>
<td style="text-align: right;">392.6</td>
<td style="text-align: left;">52.0% (37.9–65.8)</td>
<td style="text-align: right;">15.1</td>
<td style="text-align: left;">2.0% (0.3–13.7)</td>
</tr>
<tr class="odd">
<td style="text-align: left;">M</td>
<td style="text-align: right;">488.6</td>
<td style="text-align: left;">48.0% (34.2–62.1)</td>
<td style="text-align: right;">488.6</td>
<td style="text-align: left;">48.0% (34.2–62.1)</td>
<td style="text-align: right;">712.6</td>
<td style="text-align: left;">70.0% (55.5–81.4)</td>
<td style="text-align: right;">40.7</td>
<td style="text-align: left;">4.0% (1.0–15.3)</td>
</tr>
</tbody>
</table>

<sup>Created on 2019-07-19 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>