### PR TITLE
allow tranposition for no strata

### DIFF
--- a/man/tabulate_survey.Rd
+++ b/man/tabulate_survey.Rd
@@ -11,7 +11,8 @@ tabulate_survey(x, var, strata = NULL, pretty = TRUE, wide = TRUE,
 
 tabulate_binary_survey(x, ..., strata = NULL, proptotal = FALSE,
   keep = NULL, invert = FALSE, pretty = TRUE, wide = TRUE,
-  digits = 1, method = "logit", deff = FALSE, transpose = NULL)
+  digits = 1, method = "logit", na.rm = FALSE, deff = FALSE,
+  transpose = NULL)
 }
 \arguments{
 \item{x}{a survey design object}
@@ -58,10 +59,10 @@ created.}
 
 \item{invert}{if \code{TRUE}, the kept values are rejected. Defaults to \code{FALSE}}
 
-\item{transpose}{if strata is not \code{NULL} and \code{wide = TRUE}, then this will
-transpose the columns to the rows, which is useful when you stratify by
-age group. Default is \code{NULL}, which will not transpose anything. You have
-three options for transpose:
+\item{transpose}{if \code{wide = TRUE}, then this will transpose the columns to
+the rows, which is useful when you stratify by age group. Default is
+\code{NULL}, which will not transpose anything. You have three options for
+transpose:
 \itemize{
 \item \code{transpose = "variable"}: uses the variable column, dropping values.
 Use this if you know that your values are all identical or at least
@@ -71,6 +72,7 @@ Use this if your values are important and the variable names are
 generic placeholders.
 \item \code{transpose = "both"}    : combines the variable and value columns.
 Use this if both the variables and values are important.
+If there is no stratification, the results will produce a single-row table
 }}
 }
 \value{

--- a/tests/testthat/test-tabulate_survey.R
+++ b/tests/testthat/test-tabulate_survey.R
@@ -264,7 +264,7 @@ test_that("tabulate_binary_survey returns complementary proportions", {
 })
 
 
-test_that("transposition doesn't happen without strata", {
+test_that("transposition can happen without strata", {
 
   bin_trn <- tabulate_binary_survey(s,
                                     awards,
@@ -277,7 +277,12 @@ test_that("transposition doesn't happen without strata", {
                                     transpose = "variable",
                                     keep      = "Yes")
   
-  expect_identical(bin_trn, bin_tot)
+  # has one row
+  expect_equal(nrow(bin_trn), 1L)
+  # has nrow * (ncol - 2) columns
+  expect_equal(ncol(bin_trn), nrow(bin_tot) * (ncol(bin_tot) - 2L))
+  # the summation of the values are equal
+  expect_equal(sum(bin_trn), sum(bin_tot[-(1:2)]))
 
 })
 


### PR DESCRIPTION
This will remove the 'variable' and 'value' columns

I've also added the missing na.rm argument to tbs.