### PR TITLE
Nb relevel

### DIFF
--- a/inst/rmarkdown/templates/ajs_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/ajs_outbreak/skeleton/skeleton.Rmd
@@ -636,7 +636,8 @@ linelist_cleaned <- linelist_cleaned %>%
 # change the order of levels of multiple categorical variables
 linelist_cleaned <- linelist_cleaned %>%
   mutate_at(vars(starts_with("dehydration")), 
-            list(~factor(., levels = c("None", "Some", "Severe", "Unknown")))
+            fct_relevel,
+            "None", "Some", "Severe", "Unknown"
            )
 
 # Create a factor variable based on rules from other simple character variables

--- a/inst/rmarkdown/templates/ajs_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/ajs_outbreak/skeleton/skeleton.Rmd
@@ -635,9 +635,9 @@ linelist_cleaned <- linelist_cleaned %>%
 
 # Change the order of levels of multiple categorical variables
 linelist_cleaned <- linelist_cleaned %>%
-  mutate_at(vars(starts_with("test")),          #Looks for variables beginning with "test"
+  mutate_at(vars(starts_with("test")),          # Looks for variables beginning with "test"
             fct_relevel,
-            "Positive", "Negative", "Not done"  #Sets order of levels
+            "Positive", "Negative", "Not done"  # Sets order of levels
            )
 
 # Create a factor variable based on rules from other simple character variables

--- a/inst/rmarkdown/templates/ajs_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/ajs_outbreak/skeleton/skeleton.Rmd
@@ -633,12 +633,12 @@ linelist_cleaned <- linelist_cleaned %>%
                                            ">24-48 hours", 
                                            ">48 hours")))
 
-# Optional: Uncomment code below to change the order of levels of multiple categorical variables
-#linelist_cleaned <- linelist_cleaned %>%
-#  mutate_at(vars(starts_with("test")),          #Looks for variables beginning with "test"
-#            fct_relevel,
-#            "Negative", "Positive", "Not done"  #Sets order of levels
-#           )
+# Change the order of levels of multiple categorical variables
+linelist_cleaned <- linelist_cleaned %>%
+  mutate_at(vars(starts_with("test")),          #Looks for variables beginning with "test"
+            fct_relevel,
+            "Positive", "Negative", "Not done"  #Sets order of levels
+           )
 
 # Create a factor variable based on rules from other simple character variables
 # If you have access to lab results, you can create a case definition variable 

--- a/inst/rmarkdown/templates/cholera_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/cholera_outbreak/skeleton/skeleton.Rmd
@@ -4,6 +4,14 @@ output:
   word_document:
     keep_md: true
 ---
+#HOT POTATO
+# Neale is tossing a hot potato 
+# (and testing his ability to edit, push, commit, and pull request)
+# Please reject this
+
+#Testing a second time
+
+
 
 # Introduction to this template
 

--- a/inst/rmarkdown/templates/cholera_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/cholera_outbreak/skeleton/skeleton.Rmd
@@ -579,9 +579,9 @@ linelist_cleaned <- linelist_cleaned %>%
 
 # change the order of levels of multiple categorical variables
 linelist_cleaned <- linelist_cleaned %>%
-  mutate_at(vars(starts_with("dehydration")), 
+  mutate_at(vars(starts_with("dehydration")), # Looks for variables starting with "dehydration"
             fct_relevel,
-            "None", "Some", "Severe", "Unknown"
+            "None", "Some", "Severe", "Unknown" # Sets order of levels
            )
 
 # Create a factor variable based on rules from other simple character variables

--- a/inst/rmarkdown/templates/cholera_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/cholera_outbreak/skeleton/skeleton.Rmd
@@ -4,14 +4,6 @@ output:
   word_document:
     keep_md: true
 ---
-#HOT POTATO
-# Neale is tossing a hot potato 
-# (and testing his ability to edit, push, commit, and pull request)
-# Please reject this
-
-#Testing a second time
-
-
 
 # Introduction to this template
 
@@ -588,7 +580,8 @@ linelist_cleaned <- linelist_cleaned %>%
 # change the order of levels of multiple categorical variables
 linelist_cleaned <- linelist_cleaned %>%
   mutate_at(vars(starts_with("dehydration")), 
-            list(~factor(., levels = c("None", "Some", "Severe", "Unknown")))
+            fct_relevel,
+            "None", "Some", "Severe", "Unknown"
            )
 
 # Create a factor variable based on rules from other simple character variables

--- a/inst/rmarkdown/templates/measles_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/measles_outbreak/skeleton/skeleton.Rmd
@@ -627,8 +627,9 @@ linelist_cleaned <- linelist_cleaned %>%
 
 # change the order of levels of multiple categorical variables
 linelist_cleaned <- linelist_cleaned %>%
-  mutate_at(vars(starts_with("dehydration")), 
-            list(~factor(., levels = c("None", "Some", "Severe", "Unknown")))
+  mutate_at(vars(starts_with("dehydration")),
+            fct_relevel,
+            "None", "Some", "Severe", "Unknown"
            )
 
 # Create a factor variable based on rules from other simple character variables

--- a/inst/rmarkdown/templates/measles_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/measles_outbreak/skeleton/skeleton.Rmd
@@ -625,12 +625,12 @@ linelist_cleaned <- linelist_cleaned %>%
                                        "Yes - verbal",
                                        "Yes - vaccination card/ink"))
 
-# Optional: Uncomment code below to change the order of levels of multiple categorical variables
-#linelist_cleaned <- linelist_cleaned %>%
-#  mutate_at(vars(starts_with("prescribed")),   #Looks for variables beginning with "prescribed"
-#            fct_relevel,                     
-#            "No", "Yes"                        #Sets order of levels to "No" then "Yes"
-#           )
+# Change the order of levels of multiple categorical variables
+linelist_cleaned <- linelist_cleaned %>%
+  mutate_at(vars(starts_with("prescribed")),   # Looks for variables beginning with "prescribed"
+            fct_relevel,                     
+            "Yes", "No"                        # Sets order of levels
+           )
 
 # Create a factor variable based on rules from other simple character variables
 # If you have access to lab results, you can create a case definition variable 

--- a/inst/rmarkdown/templates/meningitis_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/meningitis_outbreak/skeleton/skeleton.Rmd
@@ -631,7 +631,8 @@ linelist_cleaned <- linelist_cleaned %>%
 # change the order of levels of multiple categorical variables
 linelist_cleaned <- linelist_cleaned %>%
   mutate_at(vars(starts_with("dehydration")), 
-            list(~factor(., levels = c("None", "Some", "Severe", "Unknown")))
+            fct_relevel,
+            "None", "Some", "Severe", "Unknown"
            )
 
 # Create a factor variable based on rules from other simple character variables

--- a/inst/rmarkdown/templates/meningitis_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/meningitis_outbreak/skeleton/skeleton.Rmd
@@ -632,7 +632,7 @@ linelist_cleaned <- linelist_cleaned %>%
 linelist_cleaned <- linelist_cleaned %>%
   mutate_at(vars(starts_with("seizure")), # Looks for variables beginning with "seizure"
             fct_relevel,
-            "Yes", "No"                   # Sets order of levels to "No" then "Yes"
+            "Yes", "No"                   # Sets order of levels
            )
 
 # Create a factor variable based on rules from other simple character variables

--- a/inst/rmarkdown/templates/meningitis_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/meningitis_outbreak/skeleton/skeleton.Rmd
@@ -628,12 +628,12 @@ linelist_cleaned <- linelist_cleaned %>%
                                            ">48 hours")
   ))
 
-# Optional: Uncomment code below to change the order of levels of multiple categorical variables
-#linelist_cleaned <- linelist_cleaned %>%
-#  mutate_at(vars(starts_with("seizure")), #Looks for variables beginning with "seizure"
-#            fct_relevel,
-#            "No", "Yes"                   #Sets order of levels to "No" then "Yes"
-#           )
+# Change the order of levels of multiple categorical variables
+linelist_cleaned <- linelist_cleaned %>%
+  mutate_at(vars(starts_with("seizure")), # Looks for variables beginning with "seizure"
+            fct_relevel,
+            "Yes", "No"                   # Sets order of levels to "No" then "Yes"
+           )
 
 # Create a factor variable based on rules from other simple character variables
 # If you have access to lab results and symptoms, you can create a case


### PR DESCRIPTION
Updated the four outbreak templates to use fct_relevel() instead of level() for the multi-variable re-ordering of factor levels. The level values have their own line so as to be a easily editable as possible (not inside parentheses or next to important periods, etc.) .