### PR TITLE
Nb case when

### DIFF
--- a/inst/rmarkdown/templates/ajs_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/ajs_outbreak/skeleton/skeleton.Rmd
@@ -535,7 +535,8 @@ linelist_cleaned <- linelist_cleaned %>%
 # linelist_cleaned <- mutate(linelist_cleaned, 
 #                            age_years = case_when(
 #                              age_years < 0   ~ NA_integer_, 
-#                              age_years > 120 ~ NA_integer_
+#                              age_years > 120 ~ NA_integer_,
+#                              TRUE            ~ as.integer(age_years) #Preserves other values
 #                            ))
 
 ## OPTIONAL: create an age_months variable from decimal years variable

--- a/inst/rmarkdown/templates/ajs_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/ajs_outbreak/skeleton/skeleton.Rmd
@@ -652,6 +652,7 @@ linelist_cleaned <- linelist_cleaned %>%
 #
 linelist_cleaned <- linelist_cleaned %>%
   mutate(case_def = case_when(
+    is.na(hep_e_rdt) & is.na(other_cases_in_hh)           ~ NA_character_,
     hep_e_rdt == "Positive"                               ~ "Confirmed",
     hep_e_rdt != "Positive" & other_cases_in_hh == "Yes"  ~ "Probable",
     TRUE                                                  ~ "Suspected"

--- a/inst/rmarkdown/templates/cholera_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/cholera_outbreak/skeleton/skeleton.Rmd
@@ -487,7 +487,8 @@ linelist_cleaned <- linelist_cleaned %>%
 # linelist_cleaned <- mutate(linelist_cleaned, 
 #                            age_years = case_when(
 #                              age_years < 0   ~ NA_integer_, 
-#                              age_years > 120 ~ NA_integer_
+#                              age_years > 120 ~ NA_integer_,
+#                              TRUE            ~ as.integer(age_years)
 #                            ))
 
 ## OPTIONAL: create an age_months variable from decimal years variable

--- a/inst/rmarkdown/templates/cholera_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/cholera_outbreak/skeleton/skeleton.Rmd
@@ -486,9 +486,10 @@ linelist_cleaned <- linelist_cleaned %>%
 ## OPTIONAL: change those who are above or below a certain age to NA
 # linelist_cleaned <- mutate(linelist_cleaned, 
 #                            age_years = case_when(
-#                              age_years < 0   ~ NA_integer_, 
-#                              age_years > 120 ~ NA_integer_,
-#                              TRUE            ~ as.integer(age_years)
+#                              is.na(age_years) ~ NA_integer_,
+#                              age_years < 0    ~ NA_integer_, 
+#                              age_years > 120  ~ NA_integer_,
+#                              TRUE             ~ as.integer(age_years)
 #                            ))
 
 ## OPTIONAL: create an age_months variable from decimal years variable
@@ -593,6 +594,7 @@ linelist_cleaned <- linelist_cleaned %>%
 # TRUE assigns all remaining rows 
 # linelist_cleaned <- linelist_cleaned %>%
 #   mutate(case_def = case_when(
+#     is.na(test_result)                            ~ NA_character_,
 #     test_result == "Positive"                     ~ "Confirmed",
 #     test_result == "Negative" & symptoms == "Yes" ~ "Probable",
 #     test_result == "Negative"                     ~ "Suspected",
@@ -606,6 +608,9 @@ linelist_cleaned <- linelist_cleaned %>%
 # TRUE assigns all remaining rows 
 linelist_cleaned <- linelist_cleaned %>%
   mutate(case_def = case_when(
+    is.na(cholera_pcr_result) &
+      is.na(cholera_culture_result) &
+      is.na(cholera_rdt_result)               ~ NA_character_,
     grepl("Positive", cholera_pcr_result)     ~ "Confirmed",  
     grepl("Positive", cholera_culture_result) ~ "Confirmed",
     grepl("Positive", cholera_rdt_result)     ~ "Probable",

--- a/inst/rmarkdown/templates/measles_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/measles_outbreak/skeleton/skeleton.Rmd
@@ -535,15 +535,16 @@ linelist_cleaned <- linelist_cleaned %>%
 ## OPTIONAL: change those who are above or below a certain age to NA
 # linelist_cleaned <- mutate(linelist_cleaned, 
 #                            age_years = case_when(
-#                              age_years < 0   ~ NA_integer_, 
-#                              age_years > 120 ~ NA_integer_,
-#                              TRUE            ~ as.integer(age_years) #Preserves other values
+#                              is.na(age_years) ~ NA_integer_,
+#                              age_years < 0    ~ NA_integer_, 
+#                              age_years > 120  ~ NA_integer_,
+#                              TRUE             ~ as.integer(age_years) #Preserves other values
 #                            ))
 
 ## OPTIONAL: create an age_months variable from decimal years variable
 # linelist_cleaned <- mutate(linelist_cleaned,
 #                            age_months = case_when(
-#                              age_years < 5 ~ age_years * 12
+#                              age_years < 5    ~ age_years * 12
 #                              )) 
 
 

--- a/inst/rmarkdown/templates/measles_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/measles_outbreak/skeleton/skeleton.Rmd
@@ -536,7 +536,8 @@ linelist_cleaned <- linelist_cleaned %>%
 # linelist_cleaned <- mutate(linelist_cleaned, 
 #                            age_years = case_when(
 #                              age_years < 0   ~ NA_integer_, 
-#                              age_years > 120 ~ NA_integer_
+#                              age_years > 120 ~ NA_integer_,
+#                              TRUE            ~ as.integer(age_years) #Preserves other values
 #                            ))
 
 ## OPTIONAL: create an age_months variable from decimal years variable

--- a/inst/rmarkdown/templates/meningitis_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/meningitis_outbreak/skeleton/skeleton.Rmd
@@ -535,7 +535,8 @@ linelist_cleaned <- linelist_cleaned %>%
 # linelist_cleaned <- mutate(linelist_cleaned, 
 #                            age_years = case_when(
 #                              age_years < 0   ~ NA_integer_, 
-#                              age_years > 120 ~ NA_integer_
+#                              age_years > 120 ~ NA_integer_,
+#                              TRUE            ~ as.integer(age_years) #Preserves other values
 #                            ))
 
 ## OPTIONAL: create an age_months variable from decimal years variable

--- a/inst/rmarkdown/templates/meningitis_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/meningitis_outbreak/skeleton/skeleton.Rmd
@@ -531,12 +531,13 @@ linelist_cleaned <- linelist_cleaned %>%
   ))
 
 
-## OPTIONAL: change those who are above or below a certain age to NA
-# linelist_cleaned <- mutate(linelist_cleaned, 
+# OPTIONAL: change those who are above or below a certain age to NA
+# linelist_cleaned <- mutate(linelist_cleaned,
 #                            age_years = case_when(
-#                              age_years < 0   ~ NA_integer_, 
-#                              age_years > 120 ~ NA_integer_,
-#                              TRUE            ~ as.integer(age_years) #Preserves other values
+#                              is.na(age_years) ~ NA_integer_,
+#                              age_years < 0    ~ NA_integer_,
+#                              age_years > 120  ~ NA_integer_,
+#                              TRUE             ~ as.integer(age_years) #Preserves other values
 #                            ))
 
 ## OPTIONAL: create an age_months variable from decimal years variable
@@ -597,6 +598,8 @@ linelist_cleaned <- linelist_cleaned %>%
     exit_status == "Left against medical advice"              ~ "Left"
   ),
   previously_vaccinated = case_when(
+    is.na(vaccinated_meningitis_mvc) & 
+      is.na(vaccinated_meningitis_routine)                    ~ NA_character_,
     grepl("Yes", vaccinated_meningitis_mvc)                   ~ "Yes",
     grepl("Yes", vaccinated_meningitis_routine)               ~ "Yes",
     vaccinated_meningitis_routine == "No" &
@@ -646,6 +649,9 @@ linelist_cleaned <- linelist_cleaned %>%
 
 linelist_cleaned <- linelist_cleaned %>%
   mutate(case_def = case_when(
+    is.na(pastorex_result) & is.na(fever) & 
+      is.na(stiff_neck) & 
+      is.na(petechiae_purpura_at_admission)                 ~ NA_character_,                 
     grepl("Mening", pastorex_result)                        ~ "Confirmed",
     fever == "Yes" & stiff_neck == "Yes"                    ~ "Probable",
     fever == "Yes" & 


### PR DESCRIPTION
I went through the templates and evaluated the uses of case_when, adding is.na() lines and TRUE lines as seemed necessary.

I believe there are three types of case_when situations in our code:
1) There is no TRUE statement, e.g. creating age_months from decimal years only for patients under 5y
2) There is a TRUE statement and it directs to a default outcome like TRUE ~ "Unknown" or "Suspected". This scenario matches the "WAT" example and requires an is.na() statement as well.
3) There is a TRUE statement and it directs back to the original column e.g. TRUE ~ as.integer(age_years)

Scenario 3 (which I was testing originally) shouldn't need an is.na() statement, because the NA's would be caught by TRUE and remain NA. However, in I have added the is.na() statements anyway (feel free to comment/edit further in the pull requests)

There are some chunks for case definitions where the is.na() line required multiple is.na() statements (one for each of the variables involved) - can someone please double check that these are correct?
Thanks for reviewing! 
 