### PR TITLE
Fix 171 ar missing

### DIFF
--- a/R/cfr.R
+++ b/R/cfr.R
@@ -193,6 +193,8 @@ proportion <- function(x, n, conf_level = 0.95, multiplier = 100) {
   res[missing_data, ] <- NA_real_
 
   colnames(res) <- c("x", "n", "prop", "lower", "upper")
+  res$x     <- x
+  res$n     <- n
   res$prop  <- (x / n)   * multiplier
   res$lower <- res$lower * multiplier
   res$upper <- res$upper * multiplier

--- a/R/cfr.R
+++ b/R/cfr.R
@@ -146,13 +146,15 @@ proportion <- function(x, n, conf_level = 0.95, multiplier = 100) {
   stopifnot(is.numeric(conf_level), conf_level >= 0, conf_level <= 1)
   n <- if (length(n) < length(x)) rep(n, length(x)) else n
   missing_data <- is.na(n) | is.na(x)
-  x[missing_data] <- 100
-  n[missing_data] <- 100
-  res <- binom::binom.wilson(x, n, conf.level = conf_level)
+  temp_x <- x
+  temp_n <- n
+  temp_x[missing_data] <- 100
+  temp_n[missing_data] <- 100
+  res <- binom::binom.wilson(temp_x, temp_n, conf.level = conf_level)
   res <- res[, c("x", "n", "mean", "lower", "upper")]
   res[missing_data, ] <- NA_real_
   colnames(res) <- c("x", "n", "prop", "lower", "upper")
-  res$prop  <- (x / n) * multiplier
+  res$prop  <- (x / n)   * multiplier
   res$lower <- res$lower * multiplier
   res$upper <- res$upper * multiplier
   res

--- a/R/cfr.R
+++ b/R/cfr.R
@@ -3,24 +3,35 @@
 #' Calculate attack rate, case fatality rate, and mortality rate
 #'
 #' @param x a data frame
+#'
 #' @param cases,deaths number of cases or deaths in a population. For `_df`
 #'   functions, this can be the name of a logical column OR an evaluated
 #'   logical expression (see examples).
+#'
 #' @param group the bare name of a column to use for stratifying the output
+#'
 #' @param population the number of individuals in the population.
+#'
 #' @param conf_level a number representing the confidence level for which to
 #' calculate the confidence interval. Defaults to 0.95, representinc 95%
 #' confidence interval.
+#'
 #' @param multiplier The base by which to multiply the output:
 #'  - `multiplier = 1`: ratio between 0 and 1
 #'  - `multiplier = 100`: proportion
 #'  - `multiplier = 10^4`: x per 10,000 people
+#'
 #' @param mergeCI Whether or not to put the confidence intervals in one column (default is FALSE)
+#'
 #' @param add_total if `group` is not NULL, then this will add a row containing
 #'   the total value across all groups.
+#'
 #' @param digits if `mergeCI = TRUE`, this determines how many digits are printed
+#'
 #' @export
+#'
 #' @rdname attack_rate
+#'
 #' @examples
 #' # Attack rates can be calculated with just two numbers
 #' print(ar <- attack_rate(10, 50), digits = 4) # 20% attack rate
@@ -142,9 +153,34 @@ mortality_rate <- function(deaths, population, conf_level = 0.95,
   res
 }
 
+#' get binomial estimates of proportions
+#'
+#' @param x a vector of observations/cases/deaths
+#' @param n a vector of population sizes. This can either be a single number or
+#'   a vector of the same length as x.
+#' @param conf_level confidence level for the confidence interval
+#' @param multiplier multiplier for the proportion
+#'
+#' @return a data frame with five columns: x, n, prop, lower, and upper
+#' @noRd
+#'
+#' @examples
+#' proportion(5, 10) 
+#' proportion(5, 10000) # larger populations give narrower confidence intervals
 proportion <- function(x, n, conf_level = 0.95, multiplier = 100) {
+
   stopifnot(is.numeric(conf_level), conf_level >= 0, conf_level <= 1)
-  n <- if (length(n) < length(x)) rep(n, length(x)) else n
+
+  if (length(n) != 1L && length(n) != length(x)) {
+    stop(glue::glue("the length of the population vector ({length(n)}) does not ",
+                    "match the length of the cases/deaths vector ({length(x)}). ",
+                    "These must be the same length."), call. = FALSE)
+  }
+
+  n <- rep(n, length.out = length(x))
+
+  # binom.wilson REALLY hates missing data, so we are masking it here in
+  # temporary variables
   missing_data <- is.na(n) | is.na(x)
   temp_x <- x
   temp_n <- n
@@ -152,7 +188,10 @@ proportion <- function(x, n, conf_level = 0.95, multiplier = 100) {
   temp_n[missing_data] <- 100
   res <- binom::binom.wilson(temp_x, temp_n, conf.level = conf_level)
   res <- res[, c("x", "n", "mean", "lower", "upper")]
+
+  # All missing data should have NA values
   res[missing_data, ] <- NA_real_
+
   colnames(res) <- c("x", "n", "prop", "lower", "upper")
   res$prop  <- (x / n)   * multiplier
   res$lower <- res$lower * multiplier

--- a/tests/testthat/test-proportion.R
+++ b/tests/testthat/test-proportion.R
@@ -16,6 +16,13 @@ test_that("Rates work with missing data", {
 
 })
 
+test_that("mismatched data are rejected", {
+
+  err <- "the length of the population vector (2) does not match the length of the cases/deaths vector (1)"
+  expect_error(attack_rate(5, c(10, 11)), err, fixed = TRUE) 
+
+})
+
 test_that("CI gets narrower with increasing sample size", {
   # All are data frames ------
   expect_is(p5, "data.frame")

--- a/tests/testthat/test-proportion.R
+++ b/tests/testthat/test-proportion.R
@@ -4,6 +4,18 @@ p5   <- attack_rate(5, 10)
 p50  <- case_fatality_rate(50, 100)
 p500 <- attack_rate(500, 1000)
 
+test_that("Rates work with missing data", {
+
+  pna5 <- attack_rate(c(5, NA, 5), c(NA, 10, 10))
+  expect_is(pna5, "data.frame")
+
+  expect_identical(pna5$prop , c(NA, NA, p5$prop))
+  expect_identical(pna5$lower, c(NA, NA, p5$lower))
+  expect_identical(pna5$upper, c(NA, NA, p5$upper))
+  expect_identical(pna5$ar   , c(NA, NA, p5$ar))
+
+})
+
 test_that("CI gets narrower with increasing sample size", {
   # All are data frames ------
   expect_is(p5, "data.frame")
@@ -33,3 +45,4 @@ test_that("mortality rates work", {
   expect_named(mr, c("deaths", "population", "mortality per 100 000", "lower", "upper"))
   expect_equal(mr$"mortality per 100 000", 37.02, tol = 0.01)
 })
+

--- a/tests/testthat/test-proportion.R
+++ b/tests/testthat/test-proportion.R
@@ -9,10 +9,11 @@ test_that("Rates work with missing data", {
   pna5 <- attack_rate(c(5, NA, 5), c(NA, 10, 10))
   expect_is(pna5, "data.frame")
 
-  expect_identical(pna5$ar   , c(NA, NA, p5$ar))
-  expect_identical(pna5$lower, c(NA, NA, p5$lower))
-  expect_identical(pna5$upper, c(NA, NA, p5$upper))
-  expect_identical(pna5$ar   , c(NA, NA, p5$ar))
+  expect_identical(pna5$cases     , c(5 , NA, p5$cases))
+  expect_identical(pna5$population, c(NA, 10, p5$population))
+  expect_identical(pna5$ar        , c(NA, NA, p5$ar))
+  expect_identical(pna5$lower     , c(NA, NA, p5$lower))
+  expect_identical(pna5$upper     , c(NA, NA, p5$upper))
 
 })
 

--- a/tests/testthat/test-proportion.R
+++ b/tests/testthat/test-proportion.R
@@ -9,7 +9,7 @@ test_that("Rates work with missing data", {
   pna5 <- attack_rate(c(5, NA, 5), c(NA, 10, 10))
   expect_is(pna5, "data.frame")
 
-  expect_identical(pna5$prop , c(NA, NA, p5$prop))
+  expect_identical(pna5$ar   , c(NA, NA, p5$ar))
   expect_identical(pna5$lower, c(NA, NA, p5$lower))
   expect_identical(pna5$upper, c(NA, NA, p5$upper))
   expect_identical(pna5$ar   , c(NA, NA, p5$ar))
@@ -21,12 +21,15 @@ test_that("CI gets narrower with increasing sample size", {
   expect_is(p5, "data.frame")
   expect_is(p50, "data.frame")
   expect_is(p500, "data.frame")
+
   # Proportions are equal ------
-  expect_identical(p5$prop, p50$prop)
-  expect_identical(p50$prop, p500$prop)
+  expect_identical(p5$ar, p50$cfr)
+  expect_identical(p50$cfr, p500$ar)
+
   # Lower CI increases ------
   expect_lt(p5$lower, p50$lower)
   expect_lt(p50$lower, p500$lower)
+
   # Upper CI decreases ------
   expect_gt(p5$upper, p50$upper)
   expect_gt(p50$upper, p500$upper)


### PR DESCRIPTION
This PR will fix #171:

``` r
sitrep::attack_rate(c(5, NA, 5), c(NA, 10, 10))
#>   cases population ar    lower    upper
#> 1     5         NA NA       NA       NA
#> 2    NA         10 NA       NA       NA
#> 3     5         10 50 23.65931 76.34069
```

<sup>Created on 2019-08-27 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>