### PR TITLE
update case_fatality_rate_df to not drop missing

### DIFF
--- a/R/cfr.R
+++ b/R/cfr.R
@@ -13,8 +13,8 @@
 #' @param population the number of individuals in the population.
 #'
 #' @param conf_level a number representing the confidence level for which to
-#' calculate the confidence interval. Defaults to 0.95, representinc 95%
-#' confidence interval.
+#'   calculate the confidence interval. Defaults to 0.95, representing a 95%
+#'   confidence interval.
 #'
 #' @param multiplier The base by which to multiply the output:
 #'  - `multiplier = 1`: ratio between 0 and 1
@@ -91,7 +91,8 @@ case_fatality_rate_df <- function(x, deaths, group = NULL, conf_level = 0.95,
 
   # Group the data if needed
   if (wants_grouping) {
-    x <- dplyr::group_by(x, !!qgroup)
+    x <- dplyr::mutate(x, !!qgroup := forcats::fct_explicit_na(!!qgroup, "(Missing)"))
+    x <- dplyr::group_by(x, !!qgroup, .drop = FALSE)
   }
 
   # Summarise the data. Luckily, deaths can be either a column or a logical

--- a/R/tab_descriptive.R
+++ b/R/tab_descriptive.R
@@ -12,10 +12,10 @@
 #' @param drop a character vector specifying which values to drop in the
 #'   tabulation. Defaults to `NULL`, which keeps all values. 
 #'
-#' @param na.rm When `TRUE`, missing (NA) values present in `var` will be removed
-#'   from the data set with a warning, causing a change in denominator for the
-#'   tabulations.  The default is set to `FALSE`, which creates an explicit
-#'   missing value called "(Missing)".
+#' @param na.rm When `TRUE` (default), missing (NA) values present in `var`
+#'   will be removed from the data set with a warning, causing a change in
+#'   denominator for the tabulations. Setting this to `FALSE` creates an
+#'   explicit missing value called "(Missing)".
 #'
 #' @param prop_total if `TRUE` and `strata` is not `NULL`, then the totals of the
 #'   rows will be reported as proportions of the total data set, otherwise, they

--- a/man/attack_rate.Rd
+++ b/man/attack_rate.Rd
@@ -27,7 +27,7 @@ logical expression (see examples).}
 \item{population}{the number of individuals in the population.}
 
 \item{conf_level}{a number representing the confidence level for which to
-calculate the confidence interval. Defaults to 0.95, representinc 95%
+calculate the confidence interval. Defaults to 0.95, representing a 95%
 confidence interval.}
 
 \item{multiplier}{The base by which to multiply the output:

--- a/man/tab_functions.Rd
+++ b/man/tab_functions.Rd
@@ -28,10 +28,10 @@ tabulation. Defaults to \code{TRUE}, which keeps all the values.}
 \item{drop}{a character vector specifying which values to drop in the
 tabulation. Defaults to \code{NULL}, which keeps all values.}
 
-\item{na.rm}{When \code{TRUE}, missing (NA) values present in \code{var} will be removed
-from the data set with a warning, causing a change in denominator for the
-tabulations.  The default is set to \code{FALSE}, which creates an explicit
-missing value called "(Missing)".}
+\item{na.rm}{When \code{TRUE} (default), missing (NA) values present in \code{var}
+will be removed from the data set with a warning, causing a change in
+denominator for the tabulations. Setting this to \code{FALSE} creates an
+explicit missing value called "(Missing)".}
 
 \item{prop_total}{if \code{TRUE} and \code{strata} is not \code{NULL}, then the totals of the
 rows will be reported as proportions of the total data set, otherwise, they


### PR DESCRIPTION
This addresses a pattern where the user had to specify fct_explicit_na before passing to this function and that was a bit, well, meh:

``` r
library(tidyverse)
library(sitrep)
ris <- iris
ris %>%
  mutate(Species = forcats::fct_recode(Species, NULL = "setosa")) %>%
  case_fatality_rate_df(Sepal.Width < 3, group = Species, mergeCI = TRUE, add_total = TRUE)
#> Warning: Factor `Species` contains implicit NA, consider using
#> `forcats::fct_explicit_na`
#> # A tibble: 4 x 5
#>   Species    deaths population   cfr ci            
#>   <fct>       <int>      <int> <dbl> <chr>         
#> 1 versicolor     34         50    68 (54.19--79.24)
#> 2 virginica      21         50    42 (29.38--55.77)
#> 3 <NA>            2         50     4 (1.10--13.46) 
#> 4 Total          57        150    38 (30.62--45.98)
```

<sup>Created on 2019-09-03 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>


This update automatically does the explicit:

``` r
library(tidyverse)
library(sitrep)
ris <- iris
ris %>%
  mutate(Species = forcats::fct_recode(Species, NULL = "setosa")) %>%
  case_fatality_rate_df(Sepal.Width < 3, group = Species, mergeCI = TRUE, add_total = TRUE)
#> # A tibble: 4 x 5
#>   Species    deaths population   cfr ci            
#>   <fct>       <int>      <int> <dbl> <chr>         
#> 1 versicolor     34         50    68 (54.19--79.24)
#> 2 virginica      21         50    42 (29.38--55.77)
#> 3 (Missing)       2         50     4 (1.10--13.46) 
#> 4 Total          57        150    38 (30.62--45.98)
```

<sup>Created on 2019-09-03 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>