### PR TITLE
use non-strict tidyselect for tab_ funs

### DIFF
--- a/tests/testthat/test-tab_funs.R
+++ b/tests/testthat/test-tab_funs.R
@@ -245,9 +245,13 @@ test_that("survey---adding strata works", {
 
   s_res_choice  <- tab_survey(s, tidyselect::starts_with("CHOICE"), strata = strata, drop = "")
   s_res_symptom <- tab_survey(s, SYMPTOMS, strata = strata, keep = "Yes")
+  expect_warning({
+    s_warning <- tab_survey(s, c("bullsweat", SYMPTOMS), strata = strata, keep = "Yes")
+  }, "Unknown columns: `bullsweat`", fixed = TRUE)
 
   expect_equal(ncol(s_res_choice), 8L)
   expect_equal(ncol(s_res_symptom), 8L)
+  expect_equal(s_warning, s_res_symptom)
 
   sum_choice  <- s_res_choice %>% dplyr::select(dplyr::ends_with(" n")) %>% rowSums()
   sum_symptom <- s_res_symptom %>% dplyr::select(dplyr::ends_with(" n")) %>% rowSums()


### PR DESCRIPTION
This comes with a test and will fix #183

Example:

``` r
library(sitrep)
library(srvyr)
library(survey)
data(api)

# the "candy" column doesn't exist, but throws a warning
SHINY <- c("awards", "candy")
apistrat %>%
  as_survey_design(strata = stype, weights = pw) %>%
  tab_survey(SHINY)
#> Warning: Unknown columns: `candy`
#> # A tibble: 2 x 4
#>   variable value     n ci                
#>   <chr>    <chr> <dbl> <chr>             
#> 1 awards   No    2236. 36.1% (29.5--43.2)
#> 2 awards   Yes   3958. 63.9% (56.8--70.5)
```

<sup>Created on 2019-09-17 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>