### PR TITLE
update column checking for tab_general

### DIFF
--- a/R/relabel_proportions.R
+++ b/R/relabel_proportions.R
@@ -70,15 +70,15 @@ augment_redundant <- function(x, ...) {
 #'   dots_to_charlist()
 #' }
 #' x(a = 1, b = TRUE, c = three)
-dots_to_charlist <- function() {
-  sp <- sys.parent(n = 1L)
+dots_to_charlist <- function(parent = 1L) {
+  sp <- sys.parent(n = parent)
   if (sp == 0) {
     stop('dots_to_charlist() can only be called within a user-facing function')
   }
   pairs <- match.call(definition  = sys.function(sp),
                       call        = sys.call(sp),
                       expand.dots = FALSE,
-                      envir       = parent.frame(2L))[["..."]]
+                      envir       = parent.frame(parent + 1L))[["..."]]
   pairs <- lapply(pairs, as.character)
   pairs
 }

--- a/R/tab_descriptive.R
+++ b/R/tab_descriptive.R
@@ -245,6 +245,18 @@ tab_general <-  function(x,
   # which will warn about which columns were not recognised.
   if (length(vars) == 0) {
     vars <- tidyselect::vars_select(colnames(x), tidyselect::one_of(...), .strict = FALSE)
+    if (length(vars) == 0) {
+      stop("No columns matched the data", call. = FALSE)
+    }
+  } else {
+    the_dots <- dots_to_charlist(parent = 2L)
+    # we want to tally the dots that don't match up
+    if (length(the_dots) > 1 && length(the_dots) > length(vars)) {
+      no_bueno <- glue::glue_collapse(glue::glue("`{setdiff(the_dots, vars)}`"),
+                                      sep = ", ")
+      warning(glue::glue("Unknown columns: {no_bueno}"), call. = FALSE)
+      
+    }
   }
 
   stra    <- rlang::enquo(strata)

--- a/tests/testthat/test-tab_funs.R
+++ b/tests/testthat/test-tab_funs.R
@@ -166,6 +166,25 @@ tbs_expect_symptom <- tibble::tribble(
 SYMPTOMS <- c("itch", "fever", "bleeding")
 
 
+# Error tests {{{
+
+test_that("specifying all columns that do not match will throw an error", {
+  
+  expect_warning({
+    expect_error(tab_survey(nss, "bullsweat"), "No columns matched the data")
+  }, "Unknown columns: `bullsweat`")
+
+  expect_warning({
+    tab_survey(nss, itch, bullsweat, office, clothes) %>%
+      expect_is("tbl_df") %>%
+      expect_named(c("variable", "value", "n", "ci"))
+  }, "Unknown columns: `bullsweat`, `office`, `clothes`")  
+
+})
+
+
+# }}}
+
 # Basic tests---no strata {{{
 
 # These tests will check that tab_survey and tab_linelist can both handle the


### PR DESCRIPTION
This will catch different situations where users input variables so that they get sensible results.

If none of the columns the user wants exists, they will get an error that makes sense. 

```r
tab_linelist(linelist_cleaned, fluffy, teddy, bears)
#> Error: no columns matched the data
#> warning: Unknown columns: `fluffy`, `teddy`, `bears` 
```

It will, however report columns that didn't match if some matched (previously, it wouldn't even report those:

```r
tab_linelist(linelist_cleaned, vaccinated, eyeballs)
#> warning: Unknown columns: `eyeballs`
```
