### PR TITLE
replace sprintf/paste withs str_glue in outbreak templates

### DIFF
--- a/inst/rmarkdown/templates/ajs_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/ajs_outbreak/skeleton/skeleton.Rmd
@@ -121,8 +121,7 @@ reporting_week <- aweek::as.aweek("2019-W25")
 epicurve_labels <- labs(x = "Calendar week", 
                         y = "Cases (n)", 
                         title = "Cases by week of onset",
-                        subtitle = sprintf("Source: MSF data from %s", 
-                                           reporting_week)
+                        subtitle = str_glue("Source: MSF data from {reporting_week}")
                        ) 
 ```
 
@@ -930,7 +929,7 @@ of the reporting period.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
 ```{r report_setup}
 # return the last day of the reporting week
-obs_end   <- week2date(str_glue(reporting_week, "-7"))
+obs_end   <- week2date(str_glue("{reporting_week}-7"))
 
 # filter out cases after end of reporting week
 linelist_cleaned <- linelist_cleaned %>% 
@@ -955,7 +954,7 @@ This automatically names your file "linelist_cleaned_DATE", where DATE is the
 current date.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
 ```{r save_cleaned_data}
-# rio::export(linelist_cleaned, paste0("linelist_cleaned_", Sys.Date(), ".xlsx"))
+# rio::export(linelist_cleaned, str_glue("linelist_cleaned_{Sys.Date()}.xlsx"))
 ```
 
 
@@ -1957,7 +1956,7 @@ ggplot(ar_region, aes(x = reorder(Region, `AR (per 10,000)`),
   scale_y_continuous(expand = c(0,0)) +  
   # add labels to axes and below chart
   labs(x = "Region", y = "AR (per 10,000)", 
-       captions = paste0("Source: MSF data from ", reporting_week)) + 
+       captions = str_glue("Source: MSF data from {reporting_week}")) + 
   epicurve_theme
 ```
 
@@ -2207,7 +2206,7 @@ for (i in unique(cases$epiweek)) {
     scale_y_continuous(expand = c(0, 0), limits = c(0, max_ar)) +  
     # add labels to axes and below chart
     labs(x = "Region", y = "AR (per 10,000)", 
-         captions = paste0("Source: MSF data from ", reporting_week)) + 
+         captions = str_glue("Source: MSF data from {reporting_week}")) + 
     epicurve_theme
   
   
@@ -2215,7 +2214,7 @@ for (i in unique(cases$epiweek)) {
   # combine the barplot and map plot into one
   print(
     cowplot::plot_grid(
-      barplot + labs(title = paste0("Epiweek: ", i)),
+      barplot + labs(title = str_glue("Epiweek: {i}")),
       map_plot,
       nrow = 1,
       align = "h",

--- a/inst/rmarkdown/templates/cholera_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/cholera_outbreak/skeleton/skeleton.Rmd
@@ -121,8 +121,7 @@ reporting_week <- aweek::as.aweek("2019-W25")
 epicurve_labels <- labs(x = "Calendar week", 
                         y = "Cases (n)", 
                         title = "Cases by week of onset",
-                        subtitle = sprintf("Source: MSF data from %s", 
-                                           reporting_week)
+                        subtitle = str_glue("Source: MSF data from {reporting_week}")
                        ) 
 ```
 
@@ -920,7 +919,7 @@ of the reporting period.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
 ```{r report_setup}
 # return the last day of the reporting week
-obs_end   <- week2date(str_glue(reporting_week, "-7"))
+obs_end   <- week2date(str_glue("{reporting_week}-7"))
 
 # filter out cases after end of reporting week
 linelist_cleaned <- linelist_cleaned %>% 
@@ -945,7 +944,7 @@ This automatically names your file "linelist_cleaned_DATE", where DATE is the
 current date.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
 ```{r save_cleaned_data}
-# rio::export(linelist_cleaned, paste0("linelist_cleaned_", Sys.Date(), ".xlsx"))
+# rio::export(linelist_cleaned, str_glue("linelist_cleaned_{Sys.Date()}.xlsx"))
 ```
 
 
@@ -1998,7 +1997,7 @@ ggplot(ar_region, aes(x = reorder(Region, `AR (per 10,000)`),
   scale_y_continuous(expand = c(0,0)) +  
   # add labels to axes and below chart
   labs(x = "Region", y = "AR (per 10,000)", 
-       captions = paste0("Source: MSF data from ", reporting_week)) + 
+       captions = str_glue("Source: MSF data from {reporting_week}")) + 
   epicurve_theme
 ```
 
@@ -2248,7 +2247,7 @@ for (i in unique(cases$epiweek)) {
     scale_y_continuous(expand = c(0, 0), limits = c(0, max_ar)) +  
     # add labels to axes and below chart
     labs(x = "Region", y = "AR (per 10,000)", 
-         captions = paste0("Source: MSF data from ", reporting_week)) + 
+         captions = str_glue("Source: MSF data from {reporting_week}")) + 
     epicurve_theme
   
   
@@ -2256,7 +2255,7 @@ for (i in unique(cases$epiweek)) {
   # combine the barplot and map plot into one
   print(
     cowplot::plot_grid(
-      barplot + labs(title = paste0("Epiweek: ", i)),
+      barplot + labs(title = str_glue("Epiweek: {i}")),
       map_plot,
       nrow = 1,
       align = "h",

--- a/inst/rmarkdown/templates/measles_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/measles_outbreak/skeleton/skeleton.Rmd
@@ -121,8 +121,7 @@ reporting_week <- aweek::as.aweek("2019-W25")
 epicurve_labels <- labs(x = "Calendar week", 
                         y = "Cases (n)", 
                         title = "Cases by week of onset",
-                        subtitle = sprintf("Source: MSF data from %s", 
-                                           reporting_week)
+                        subtitle = str_glue("Source: MSF data from {reporting_week}")
                        ) 
 ```
 
@@ -865,7 +864,7 @@ linelist_cleaned <- linelist_cleaned %>%
 ## Change the order of levels of multiple categorical variables at the same time
 linelist_cleaned <- linelist_cleaned %>%
   mutate_at(vars(
-           # Looks for variables beginning with "seizure"
+           # Looks for variables beginning with "prescribed"
             starts_with("prescribed")),          
             fct_relevel,
             # Sets order of levels
@@ -912,7 +911,7 @@ of the reporting period.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
 ```{r report_setup}
 # return the last day of the reporting week
-obs_end   <- week2date(str_glue(reporting_week, "-7"))
+obs_end   <- week2date(str_glue("{reporting_week}-7"))
 
 # filter out cases after end of reporting week
 linelist_cleaned <- linelist_cleaned %>% 
@@ -924,6 +923,7 @@ first_week <- as.aweek(min(as.character(linelist_cleaned$epiweek)))
 # outbreak start 
 # return the first day in the week of first case 
 obs_start <- as.Date(first_week)
+
 ```
 
 
@@ -937,7 +937,7 @@ This automatically names your file "linelist_cleaned_DATE", where DATE is the
 current date.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
 ```{r save_cleaned_data}
-# rio::export(linelist_cleaned, paste0("linelist_cleaned_", Sys.Date(), ".xlsx"))
+# rio::export(linelist_cleaned, str_glue("linelist_cleaned_{Sys.Date()}.xlsx"))
 ```
 
 
@@ -1969,7 +1969,7 @@ ggplot(ar_region, aes(x = reorder(Region, `AR (per 10,000)`),
   scale_y_continuous(expand = c(0,0)) +  
   # add labels to axes and below chart
   labs(x = "Region", y = "AR (per 10,000)", 
-       captions = paste0("Source: MSF data from ", reporting_week)) + 
+       captions = str_glue("Source: MSF data from {reporting_week}")) + 
   epicurve_theme
 ```
 
@@ -2219,7 +2219,7 @@ for (i in unique(cases$epiweek)) {
     scale_y_continuous(expand = c(0, 0), limits = c(0, max_ar)) +  
     # add labels to axes and below chart
     labs(x = "Region", y = "AR (per 10,000)", 
-         captions = paste0("Source: MSF data from ", reporting_week)) + 
+         captions = str_glue("Source: MSF data from {reporting_week}")) + 
     epicurve_theme
   
   
@@ -2227,7 +2227,7 @@ for (i in unique(cases$epiweek)) {
   # combine the barplot and map plot into one
   print(
     cowplot::plot_grid(
-      barplot + labs(title = paste0("Epiweek: ", i)),
+      barplot + labs(title = str_glue("Epiweek: {i}")),
       map_plot,
       nrow = 1,
       align = "h",

--- a/inst/rmarkdown/templates/meningitis_outbreak/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/meningitis_outbreak/skeleton/skeleton.Rmd
@@ -121,8 +121,7 @@ reporting_week <- aweek::as.aweek("2019-W25")
 epicurve_labels <- labs(x = "Calendar week", 
                         y = "Cases (n)", 
                         title = "Cases by week of onset",
-                        subtitle = sprintf("Source: MSF data from %s", 
-                                           reporting_week)
+                        subtitle = str_glue("Source: MSF data from {reporting_week}")
                        ) 
 ```
 
@@ -941,7 +940,7 @@ of the reporting period.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
 ```{r report_setup}
 # return the last day of the reporting week
-obs_end   <- week2date(str_glue(reporting_week, "-7"))
+obs_end   <- week2date(str_glue("{reporting_week}-7"))
 
 # filter out cases after end of reporting week
 linelist_cleaned <- linelist_cleaned %>% 
@@ -953,6 +952,7 @@ first_week <- as.aweek(min(as.character(linelist_cleaned$epiweek)))
 # outbreak start 
 # return the first day in the week of first case 
 obs_start <- as.Date(first_week)
+
 ```
 
 
@@ -966,7 +966,7 @@ This automatically names your file "linelist_cleaned_DATE", where DATE is the
 current date.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ -->
 ```{r save_cleaned_data}
-# rio::export(linelist_cleaned, paste0("linelist_cleaned_", Sys.Date(), ".xlsx"))
+# rio::export(linelist_cleaned, str_glue("linelist_cleaned_{Sys.Date()}.xlsx"))
 ```
 
 
@@ -2029,7 +2029,7 @@ ggplot(ar_region, aes(x = reorder(Region, `AR (per 10,000)`),
   scale_y_continuous(expand = c(0,0)) +  
   # add labels to axes and below chart
   labs(x = "Region", y = "AR (per 10,000)", 
-       captions = paste0("Source: MSF data from ", reporting_week)) + 
+       captions = str_glue("Source: MSF data from {reporting_week}")) + 
   epicurve_theme
 ```
 
@@ -2279,7 +2279,7 @@ for (i in unique(cases$epiweek)) {
     scale_y_continuous(expand = c(0, 0), limits = c(0, max_ar)) +  
     # add labels to axes and below chart
     labs(x = "Region", y = "AR (per 10,000)", 
-         captions = paste0("Source: MSF data from ", reporting_week)) + 
+         captions = str_glue("Source: MSF data from {reporting_week}")) + 
     epicurve_theme
   
   
@@ -2287,7 +2287,7 @@ for (i in unique(cases$epiweek)) {
   # combine the barplot and map plot into one
   print(
     cowplot::plot_grid(
-      barplot + labs(title = paste0("Epiweek: ", i)),
+      barplot + labs(title = str_glue("Epiweek: {i}")),
       map_plot,
       nrow = 1,
       align = "h",


### PR DESCRIPTION
I had noticed there were still a couple of places where we were using paste/sprintf, so I changed them to  str_glue() for the sake of consistency.