### PR TITLE
update tab_univariate to return correct columns

### DIFF
--- a/R/tab_univariate.R
+++ b/R/tab_univariate.R
@@ -246,8 +246,8 @@ backend_tab_univariate <- function(exposure, outcome, x, perstime = NULL, strata
   # drop columns if specified
   # use numbers because names will be different according to measure, but place is always same
   if (!extend_output) {
-    to_drop <- if (has_strata) c(-5, -8, -12) else c(-4, -7, -11)
-    nums    <- nums[to_drop]
+    to_keep <- !grepl("(odds|risk|incidence)$", names(nums))
+    nums    <- nums[to_keep]
   }
 
   # drop woolf-test pvalue
@@ -259,9 +259,6 @@ backend_tab_univariate <- function(exposure, outcome, x, perstime = NULL, strata
   if (mergeCI) {
     nums <- unite_ci(nums, col = "est_ci", "ratio", "lower", "upper", m100 = FALSE, digits = digits)
   }
-
-  # change output table to a tibble
-  # nums <- tibble(nums)
 
   # spit out the out table
   return(nums)

--- a/tests/testthat/test-tab_univariate.R
+++ b/tests/testthat/test-tab_univariate.R
@@ -86,8 +86,16 @@ test_that("woolf p-values work", {
 
 
 OR_strata <- tab_univariate(arrt, outcome, risk, strata = old, measure = "OR", woolf_test = TRUE)
+OR_simple <- tab_univariate(arrt, outcome, risk, strata = old, measure = "OR", extend_output = FALSE, mergeCI = TRUE)
+OR_names <- c("variable", "est_type", "exp_cases", "unexp_cases", "exp_controls", "unexp_controls", "est_ci", "p.value")
+
 RR_strata <- tab_univariate(arrt, outcome, risk, strata = old, measure = "RR", woolf_test = TRUE)
+RR_simple <- tab_univariate(arrt, outcome, risk, strata = old, measure = "RR", extend_output = FALSE, mergeCI = TRUE)
+RR_names <- c("variable", "est_type", "exp_cases", "exp_total", "unexp_cases", "unexp_total", "est_ci", "p.value")
+
 IRR_strata <- tab_univariate(arrt, outcome, risk, strata = old, perstime = pt, measure = "IRR", woolf_test = TRUE)
+IRR_simple <- tab_univariate(arrt, outcome, risk, strata = old, perstime = pt, measure = "IRR", extend_output = FALSE, mergeCI = TRUE)
+IRR_names <- c("variable", "est_type", "exp_cases", "exp_perstime", "unexp_cases", "unexp_perstime", "est_ci", "p.value")
 
 
 test_that("tab_univariate OR works with strata", {
@@ -159,3 +167,13 @@ test_that("tab_univariate works with IRR strata", {
   expect_equal(IRR_strata$upper, expected$upper)
 
 })
+
+test_that("setting extend_output to FALSE will remove only the estimates", {
+
+  expect_named(RR_simple, RR_names)
+  expect_named(OR_simple, OR_names)
+  expect_named(IRR_simple, IRR_names)
+
+
+})
+


### PR DESCRIPTION
This will fix #205 

``` r
library("sitrep")
a <- data.frame(case_def = sample(c(TRUE, FALSE), 2000, replace = TRUE),
           riskA = sample(c(TRUE, FALSE), 2000, replace = TRUE),
           riskB = sample(c(TRUE, FALSE), 2000, replace = TRUE),
           stratifier = sample(c(TRUE, FALSE), 2000, replace = TRUE),
           perstime = sample(150:250, 2000, replace = TRUE)
           )

tab_univariate(a, case_def, riskA, riskB,
               digits = 6, measure = "OR", extend_output = FALSE, mergeCI = TRUE)
#> # A tibble: 2 x 8
#>   variable est_type exp_cases unexp_cases exp_controls unexp_controls
#>   <chr>    <chr>        <int>       <int>        <int>          <int>
#> 1 riskA    crude          495         475          503            527
#> 2 riskB    crude          492         478          528            502
#> # … with 2 more variables: est_ci <chr>, p.value <dbl>
```

<sup>Created on 2019-10-08 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>