### PR TITLE
add NEWS and generic contribution guides

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,4 @@
 ^README\.Rmd$
 ^examples
 ^codecov\.yml$
+^\.github$

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,25 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, we pledge to respect all people who 
+contribute through reporting issues, posting feature requests, updating documentation,
+submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for
+everyone, regardless of level of experience, gender, gender identity and expression,
+sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of sexual language or
+imagery, derogatory comments or personal attacks, trolling, public or private harassment,
+insults, or other unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments,
+commits, code, wiki edits, issues, and other contributions that are not aligned to this 
+Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed 
+from the project team.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by 
+opening an issue or contacting one or more of the project maintainers.
+
+This Code of Conduct is adapted from the Contributor Covenant 
+(https://www.contributor-covenant.org), version 1.0.0, available at 
+https://contributor-covenant.org/version/1/0/0/.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing to sitrep
+
+This outlines how to propose a change to sitrep. For more detailed
+info about contributing to this, and other tidyverse packages, please see the
+[**development contributing guide**](https://rstd.io/tidy-contrib).
+
+### Fixing typos
+
+Small typos or grammatical errors in documentation may be edited directly using
+the GitHub web interface, so long as the changes are made in the _source_ file.
+
+*  YES: you edit a roxygen comment in a `.R` file below `R/`.
+*  NO: you edit an `.Rd` file below `man/`.
+
+### Prerequisites
+
+Before you make a substantial pull request, you should always file an issue and
+make sure someone from the team agrees that it’s a problem. If you’ve found a
+bug, create an associated issue and illustrate the bug with a minimal 
+[reprex](https://www.tidyverse.org/help/#reprex).
+
+### Pull request process
+
+*  We recommend that you create a Git branch for each pull request (PR).  
+*  Look at the Travis and AppVeyor build status before and after making changes.
+The `README` should contain badges for any continuous integration services used
+by the package.  
+*  New code should follow the tidyverse [style guide](https://style.tidyverse.org).
+You can use the [styler](https://CRAN.R-project.org/package=styler) package to
+apply these styles, but please don't restyle code that has nothing to do with 
+your PR.  
+*  We use [roxygen2](https://cran.r-project.org/package=roxygen2), with
+[Markdown syntax](https://cran.r-project.org/web/packages/roxygen2/vignettes/markdown.html), 
+for documentation.  
+*  We use [testthat](https://cran.r-project.org/package=testthat). Contributions
+with test cases included are easier to accept.  
+*  For user-facing changes, add a bullet to the top of `NEWS.md` below the
+current development version header describing the changes made followed by your
+GitHub username, and links to relevant issue(s)/PR(s).
+
+### Code of Conduct
+
+Please note that the sitrep project is released with a
+[Contributor Code of Conduct](CODE_OF_CONDUCT.md). By contributing to this
+project you agree to abide by its terms.
+
+### See tidyverse [development contributing guide](https://rstd.io/tidy-contrib)
+for further details.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+Please briefly describe your problem and what output you expect. If you have a question, please don't use this form. Instead, ask on <https://stackoverflow.com/> or <https://community.rstudio.com/>.
+
+Please include a minimal reproducible example (AKA a reprex). If you've never heard of a [reprex](https://reprex.tidyverse.org/) before, start by reading <https://www.tidyverse.org/help/#reprex>.
+
+---
+
+Brief description of the problem
+
+```r
+# insert reprex here
+```

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,35 @@
+# Getting help with sitrep
+
+Thanks for using sitrep. Before filing an issue, there are a few places
+to explore and pieces to put together to make the process as smooth as possible.
+
+Start by making a minimal **repr**oducible **ex**ample using the 
+[reprex](https://reprex.tidyverse.org/) package. If you haven't heard of or used 
+reprex before, you're in for a treat! Seriously, reprex will make all of your 
+R-question-asking endeavors easier (which is a pretty insane ROI for the five to 
+ten minutes it'll take you to learn what it's all about). For additional reprex
+pointers, check out the [Get help!](https://www.tidyverse.org/help/) section of
+the tidyverse site.
+
+Armed with your reprex, the next step is to figure out [where to ask](https://www.tidyverse.org/help/#where-to-ask). 
+
+  * If it's a question: start with [community.rstudio.com](https://community.rstudio.com/), 
+    and/or StackOverflow. There are more people there to answer questions.  
+  * If it's a bug: you're in the right place, file an issue.  
+  * If you're not sure: let the community help you figure it out! If your 
+    problem _is_ a bug or a feature request, you can easily return here and 
+    report it. 
+
+Before opening a new issue, be sure to [search issues and pull requests](https://github.com/tidyverse/sitrep/issues) to make sure the 
+bug hasn't been reported and/or already fixed in the development version. By 
+default, the search will be pre-populated with `is:issue is:open`. You can 
+[edit the qualifiers](https://help.github.com/articles/searching-issues-and-pull-requests/) 
+(e.g. `is:pr`, `is:closed`) as needed. For example, you'd simply
+remove `is:open` to search _all_ issues in the repo, open or closed.
+
+
+If you _are_ in the right place, and need to file an issue, please review the 
+["File issues"](https://www.tidyverse.org/contribute/#issues) paragraph from 
+the tidyverse contributing guidelines.
+
+Thanks for your help!

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,4 @@
+# sitrep 0.1.0
+
+* Added a `NEWS.md` file to track changes to the package.
+* First official release of the {sitrep} package.

--- a/README.Rmd
+++ b/README.Rmd
@@ -44,3 +44,9 @@ And the development version from [GitHub](https://github.com/) with:
 # install.packages("remotes")
 remotes::install_github("R4EPI/sitrep")
 ```
+
+
+Please note that the 'sitrep' project is released with a
+[Contributor Code of Conduct](.github/CODE_OF_CONDUCT.md).
+By contributing to this project, you agree to abide by its terms.
+


### PR DESCRIPTION
This adds a NEWS file and generic contribution guidelines from usethis. I want to make sure these are present in the first release. 

Any other changes beyond this must increment the version number and list the change in the NEWS. 