### PR TITLE
edits as per email

### DIFF
--- a/inst/rmarkdown/templates/nutrition/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/nutrition/skeleton/skeleton.Rmd
@@ -54,7 +54,7 @@ In order to estimate underweight in the surveyed population, we looked at Weight
 * Severe underweight: WAZ <-3  
 
 
-Exclusion of z-scores from Observed mean SMART flags included:  
+Exclusion of z-scores from Observed mean WHO flags included:  
 * WHZ: <-5 or >5;  
 * HAZ: <-6 or >6;  
 * WAZ: <-6 or >5.  
@@ -752,7 +752,7 @@ study_data_cleaned <- bind_cols(study_data_cleaned, zscore_results)
 study_data_cleaned <- study_data_cleaned %>% 
   mutate(
     gam_whz = zwfl <  -2 | oedema == "Yes", 
-    mam_whz = zwfl >= -3 & zwei < -2, 
+    mam_whz = zwfl >= -3 & zwfl < -2 & oedema == "No", 
     sam_whz = zwfl <  -3 | oedema == "Yes"
   ) %>%
   ## set flagged children to NA for each of the indicator variables


### PR DESCRIPTION
1. For WHZ, the introduction suggests that the analysis was done on the SMART flag exclusion dataset, stating: “Exclusion of z-scores from Observed mean SMART flags included, which is inconsistent with the threshold to define the flag – WHZ: <-5 or >5.” According to the SMART Methodology Manual (2017), SMART flags exclude all values outside ±3 Z-scores from the mean of the surveyed population. Note that the anthro_zscores function used in the template identifies WHO flags (variable fwfl) and not SMART flags. While SMART exclusion is the preferred approach according to the SMART survey manual, some nutrition specialists (e.g., JL) suggest that WHO exclusion may be preferable in certain situations. For now, to avoid making extensive changes, perhaps you could keep the data analysis based on WHO flags, and simply correct the ‘SMART flags’ by ‘WHO flags’ in the introduction section. 

2. Possible coding mistake: In this block for the classification of WHZ: There’s a typo (755); it should be zwfl, not zwei.